### PR TITLE
docs: add docs and runnable examples

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,121 @@
+# Advanced usage
+
+Recipes, configuration, and the sharp edges. Skim [api.md](api.md) first for the
+signatures referenced here.
+
+## Selecting a dialect
+
+The dialect flows through the base constructor and changes which exception
+dictionary is consulted. It matters most for `NgramMWLPhonemizer`, which merges
+the dialect's exceptions into its training data:
+
+```python
+from mwl_phonemizer import NgramMWLPhonemizer
+from mwl_phonemizer.base import Dialects
+
+central   = NgramMWLPhonemizer(n=4, dialect=Dialects.CENTRAL)
+sendinese = NgramMWLPhonemizer(n=4, dialect=Dialects.SENDINESE)
+
+print(central.phonemize("lhéngua", lookup_word=False))
+print(sendinese.phonemize("lhéngua", lookup_word=False))
+```
+
+The Sendinese dialect notably realises `lh` as `l`; its exceptions live in
+`sendinese.json`, Raiano in `raiano.json`, and the Central gold in `central.json`.
+
+## Comparing engines on one word
+
+Because every engine shares the interface, comparison is a loop. Force
+`lookup_word=False` so the gold dictionary does not short-circuit the engine:
+
+```python
+from mwl_phonemizer import (
+    LookupTableMWL, NgramMWLPhonemizer, OrthographyRulesMWL, CRFOrthoCorrector,
+)
+
+engines = [LookupTableMWL(), NgramMWLPhonemizer(n=4),
+           OrthographyRulesMWL(), CRFOrthoCorrector()]
+
+for eng in engines:
+    print(f"{type(eng).__name__:22} {eng.phonemize('mirandesa', lookup_word=False)}")
+```
+
+## Scoring against the gold dictionary
+
+`evaluate_on_gold` returns mean edit distances plus a `details` list of every
+word the engine got wrong. Phoneme Error Rate (PER) is that total edit distance
+divided by the total reference length:
+
+```python
+from mwl_phonemizer import OrthographyRulesMWL
+
+eng = OrthographyRulesMWL()
+stats = eng.evaluate_on_gold()
+
+ref_len = sum(len(v) for v in eng.GOLD.values())
+per = stats["avg_edit_distance"] * stats["counts"] / ref_len
+print(f"PER (stress): {per:.2%}  over {stats['counts']} words")
+
+ref_len_ns = sum(len(eng.strip_stress(v)) for v in eng.GOLD.values())
+per_ns = stats["avg_edit_distance_no_stress"] * stats["counts"] / ref_len_ns
+print(f"PER (stress-agnostic): {per_ns:.2%}")
+
+for d in stats["details"][:5]:
+    print(f"  {d['word']:<14} gold={d['gold']:<14} got={d['phonemes']:<14} ed={d['ed']}")
+```
+
+A lower PER does not by itself mean a better phonemizer — the gold set is roughly
+150 words, so the CRF engines are overfitted to it. Treat the numbers as a
+relative sanity check, not an absolute quality score.
+
+## Training a CRF on your own data
+
+`CRFPhonemizer` retrains on every construction. Pass `train_data` — a list of
+`(orthography, gold IPA)` pairs — to train on your own aligned set instead of the
+bundled gold dictionary:
+
+```python
+from mwl_phonemizer import CRFPhonemizer
+
+pairs = [("lhéngua", "ʎɛ̃ɡwɐ"), ("mirandesa", "miɾɐ̃dezɐ"), ("fuogo", "fwoɡu")]
+eng = CRFPhonemizer(train_data=pairs, ignore_stress=True)
+print(eng.phonemize("fuogo", lookup_word=False))
+```
+
+Once trained, `eng.save_model(path)` writes the model with `joblib` and
+`eng.load_model(path)` reads it back into an existing instance.
+
+`strategy=AlignmentStrategy.LEV` aligns input and gold with Levenshtein editops;
+`AlignmentStrategy.PAD` pads the shorter sequence with `.`. The `apply_manual_fixes`
+flag turns on heuristic word-final phone patching for words ending in a vowel or a
+consonant the alignment tends to drop.
+
+## Optional backends
+
+`EspeakMWL` / `CRFEspeakCorrector` shell out to the `espeak-ng` binary;
+`EpitranMWL` / `CRFEpitranCorrector` use `epitran.Epitran("por-Latn")`. Neither
+backend is a declared dependency, so guard their use:
+
+```python
+try:
+    from mwl_phonemizer import CRFEspeakCorrector
+    eng = CRFEspeakCorrector()
+    print(eng.phonemize_sentence("Hai más fuogo alhá, i ye deimingo!"))
+except Exception as exc:
+    print("espeak-ng backend unavailable:", exc)
+```
+
+## Gotchas
+
+- `phonemize()` on the bare base `MirandesePhonemizer` raises `ValueError` for an
+  unknown word when `lookup_word=False`. Use a concrete subclass to generate.
+- With `lookup_word=True` (the default), gold words are returned verbatim, so
+  evaluation always forces `lookup_word=False`.
+- CRF engines train on import; the first construction is the slow one.
+- `OrthographyRulesMWL` defaults to `keep_stress_marks=False` — set it `True` if
+  you need stress in the output.
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and first call
+- [api.md](api.md) — full signatures and return shapes

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,188 @@
+# API reference
+
+Everything here is re-exported from the top-level `mwl_phonemizer` package or
+lives on the `mwl_phonemizer.base` module. All phonemizers subclass
+`MirandesePhonemizer` and share its `phonemize` / `phonemize_sentence` interface.
+
+## The shared interface — `MirandesePhonemizer`
+
+`from mwl_phonemizer.base import MirandesePhonemizer, Dialects`
+
+```python
+MirandesePhonemizer(
+    gold_dict: str | None = None,       # path to gold {ortho: ipa} JSON
+    raiano_dict: str | None = None,     # Raiano dialect exceptions
+    sendinese_dict: str | None = None,  # Sendinese dialect exceptions
+    dialect: Dialects = Dialects.CENTRAL,
+)
+```
+
+The constructor loads three bundled JSON dictionaries (`central.json`,
+`raiano.json`, `sendinese.json`) and runs every value through `strip_markers`.
+The loaded dictionaries are available as `self.GOLD`, `self.RAIANO_GOLD`, and
+`self.SENDINESE_GOLD`.
+
+### Methods
+
+```python
+phonemize(word: str, lookup_word: bool = True) -> str
+```
+Returns the IPA transcription of one word. With `lookup_word=True`, a word found
+in `self.GOLD` is returned verbatim. The base class raises `ValueError` for an
+unknown word when `lookup_word=False`; every concrete subclass overrides this to
+generate a transcription instead.
+
+```python
+phonemize_sentence(text: str, lookup_word: bool = True) -> str
+```
+Splits `text` into words and punctuation, phonemizes each alphabetic token, and
+re-joins everything — punctuation and spacing are preserved, and `-` is treated
+as a word separator.
+
+```python
+evaluate_on_gold(limit=None, detailed=False, show_changes=False) -> dict
+```
+Scores the phonemizer against `self.GOLD` (always with `lookup_word=False`).
+Returns a dict shaped like:
+
+```python
+{
+    "avg_edit_distance": float,            # mean edit distance, stress included
+    "avg_edit_distance_no_stress": float,  # mean edit distance, stress ignored
+    "counts": int,                          # words evaluated
+    "improvements": Counter(),              # per-rule deltas (engine-specific)
+    "details": [                            # only words with edit distance > 0
+        {"word": str, "phonemes": str, "gold": str, "ed": int},
+        ...
+    ],
+}
+```
+
+### Static helpers
+
+```python
+strip_markers(ipa: str) -> str   # removes '.', '(' and ')'
+strip_stress(ipa: str) -> str    # removes primary 'ˈ' and secondary 'ˌ' stress
+word_edit_distance(a: str, b: str) -> int   # editdistance.eval(a, b)
+```
+
+### `Dialects`
+
+A `str` enum: `Dialects.CENTRAL` (`"central"`), `Dialects.RAIANO` (`"raiano"`),
+`Dialects.SENDINESE` (`"sendinese"`).
+
+## Dependency-free phonemizers
+
+### `LookupTableMWL`
+
+`from mwl_phonemizer import LookupTableMWL`
+
+Single letter/digraph to phoneme table. `LookupTableMWL.normalize(sentence)` is a
+static method that lowercases, collapses pauses, and rewrites digraphs (`lh`,
+`nh`, `an`, `qu`, …) into internal placeholders before lookup.
+
+```python
+LookupTableMWL().phonemize("lhéngua", lookup_word=False)   # 'ʎɛnga'
+```
+
+### `NgramMWLPhonemizer`
+
+`from mwl_phonemizer import NgramMWLPhonemizer`
+
+```python
+NgramMWLPhonemizer(n: int = 4, *args, **kwargs)
+```
+Statistical n-gram G2P trained on `self.GOLD` at construction time. For
+`Dialects.RAIANO` or `Dialects.SENDINESE` the matching exception dictionary is
+merged into the training data. `n` is the n-gram order (n=4 conditions on three
+preceding graphemes).
+
+```python
+NgramMWLPhonemizer(n=4).phonemize("mirandesa", lookup_word=False)
+```
+
+### `OrthographyRulesMWL`
+
+`from mwl_phonemizer import OrthographyRulesMWL`
+
+```python
+OrthographyRulesMWL(*args, keep_optional_phones=True, keep_stress_marks=False, **kwargs)
+```
+Hand-crafted orthographic and phonological rules (lenition, sibilant variation,
+Latin cluster evolution, palatalization). `keep_optional_phones` keeps phones the
+rules mark as optional (in parentheses); `keep_stress_marks` keeps `ˈ`/`ˌ`.
+
+```python
+OrthographyRulesMWL().phonemize("lhéngua", lookup_word=False)   # 'ʎɛŋɡwa'
+```
+
+## CRF phonemizers
+
+### `CRFPhonemizer`
+
+`from mwl_phonemizer import CRFPhonemizer` (also `mwl_phonemizer.crf_mwl`)
+
+```python
+CRFPhonemizer(
+    crf_model_path: str | None = None,
+    strategy=AlignmentStrategy.LEV,    # LEV (Levenshtein editops) or PAD
+    algorithm="lbfgs",
+    c1=0.1, c2=0.1,
+    max_iterations=100,
+    all_possible_transitions=False,
+    apply_manual_fixes=False,          # heuristic word-final phone patching
+    ignore_stress=True,
+    train_data: list[tuple[str, str]] | None = None,
+    *args, **kwargs,
+)
+```
+
+Character-level CRF over aligned `(input, gold)` pairs. On construction it loads
+`crf_model_path` if the file exists, else trains on `train_data` if given, else
+trains on `self.GOLD`. Useful methods:
+
+```python
+train_crf(train_data: list[tuple[str, str]]) -> None
+save_model(path: str) -> None
+load_model(path: str) -> None
+grapheme_transforms(str_input: str) -> str   # override hook; identity by default
+```
+
+`AlignmentStrategy` is a `str` enum with `PAD` and `LEV`. Module-level helpers
+`align_with_lev(a, b)` and `align_pad(a, b)` return two equal-length lists with
+gaps marked `.`.
+
+### `CRFOrthoCorrector`
+
+`from mwl_phonemizer import CRFOrthoCorrector`
+
+Runs `OrthographyRulesMWL` first and lets the CRF correct the result — the
+lowest-PER engine, with no external binaries. Takes no required arguments.
+
+```python
+CRFOrthoCorrector().phonemize("lhéngua", lookup_word=False)   # 'ʎɛ̃ɡwɐ'
+```
+
+## Backends needing extra software
+
+These are imported lazily; constructing them without the backend installed raises
+at import/run time.
+
+### `EspeakMWL` / `CRFEspeakCorrector`
+
+`from mwl_phonemizer import EspeakMWL, CRFEspeakCorrector`
+
+Use the `espeak-ng` system binary to phonemize via Portuguese, then (for the CRF
+variant) correct it. `CRFEspeakCorrector` keeps stress (`ignore_stress=False`).
+
+### `EpitranMWL` / `CRFEpitranCorrector`
+
+`from mwl_phonemizer import EpitranMWL, CRFEpitranCorrector`
+
+Use `epitran.Epitran("por-Latn")` as the first-pass transcriber, optionally
+corrected by the CRF. Requires `pip install epitran`.
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and first call
+- [advanced.md](advanced.md) — dialects, evaluation, persistence, gotchas

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart — Mirandese text to IPA
+
+`mwl_phonemizer` turns Mirandese (mwl) text into its IPA phonetic transcription.
+Every phonemizer is a small class with the same two methods — `phonemize(word)`
+for one word and `phonemize_sentence(text)` for a whole sentence — so you can
+swap one backend for another without touching your calling code.
+
+## 1. Install
+
+```bash
+pip install -e .
+```
+
+Core dependencies (`python-Levenshtein`, `sklearn_crfsuite`, `editdistance`,
+`joblib`) come from `requirements.txt`. The CRF backends train a tiny model on
+import, so the very first construction takes a moment.
+
+Two backends need extra software that is **not** declared as a dependency and is
+imported lazily — install them only if you reach for those classes:
+
+- `epitran` (`pip install epitran`) for `EpitranMWL` / `CRFEpitranCorrector`.
+- the `espeak-ng` system binary for `EspeakMWL` / `CRFEspeakCorrector`.
+
+## 2. The one idea
+
+Every phonemizer subclasses `MirandesePhonemizer` and shares one interface:
+
+```python
+phonemizer.phonemize(word, lookup_word=True)        # -> IPA string for one word
+phonemizer.phonemize_sentence(text, lookup_word=True)  # -> IPA string, punctuation kept
+```
+
+`lookup_word=True` (the default) returns the curated gold transcription if the
+word is in the bundled dictionary, and only falls back to the model otherwise.
+Pass `lookup_word=False` to force the model/rules path — that is what you want
+when measuring how the engine actually performs.
+
+## 3. First real call
+
+`CRFOrthoCorrector` is the headline engine: hand-written orthographic rules whose
+output is cleaned up by a character-level CRF. It needs no external binaries.
+
+```python
+from mwl_phonemizer import CRFOrthoCorrector
+
+phonemizer = CRFOrthoCorrector()
+
+text = ("Muitas lhénguas ténen proua de ls sous pergaminos antigos, "
+        "cumo ye l causo de la lhéngua mirandesa.")
+print(phonemizer.phonemize_sentence(text))
+# mujtɐs̺ ʎɛ̃ɡwas̺ tɛnẽ pɾowɐ ...
+```
+
+A single word, forcing the engine path so the lookup table does not shadow it:
+
+```python
+print(phonemizer.phonemize("lhéngua", lookup_word=False))   # ʎɛ̃ɡwɐ
+```
+
+## 4. Pick a backend
+
+All of these share the interface above; they differ in accuracy and in what they
+require to run:
+
+```python
+from mwl_phonemizer import (
+    LookupTableMWL,        # letter/digraph lookup table, no dependencies
+    NgramMWLPhonemizer,    # statistical n-gram G2P, no dependencies
+    OrthographyRulesMWL,   # hand-crafted orthographic rules, no dependencies
+    CRFOrthoCorrector,     # rules + CRF correction (best PER), no external binaries
+)
+
+for cls in (LookupTableMWL, NgramMWLPhonemizer, OrthographyRulesMWL, CRFOrthoCorrector):
+    print(cls.__name__, cls().phonemize("mirandesa", lookup_word=False))
+```
+
+See [api.md](api.md) for the full class list and signatures.
+
+## 5. Clean up the output
+
+The base class ships two static helpers for normalising IPA before comparison:
+
+```python
+from mwl_phonemizer.base import MirandesePhonemizer
+
+MirandesePhonemizer.strip_markers("ˈe(j).ʒɛmˈplu")   # 'ˈejʒɛmˈplu'  — drop . ( )
+MirandesePhonemizer.strip_stress("miɾɐ̃ˈdes̺")        # 'miɾɐ̃des̺'    — drop ˈ ˌ
+```
+
+## Where next
+
+- [api.md](api.md) — every public class, signature, and return shape
+- [advanced.md](advanced.md) — dialects, evaluation, model persistence, gotchas

--- a/examples/01_first_call.py
+++ b/examples/01_first_call.py
@@ -1,0 +1,25 @@
+"""Phonemize a Mirandese sentence with the headline CRF+rules engine.
+
+Run::
+
+    python examples/01_first_call.py
+"""
+from mwl_phonemizer import CRFOrthoCorrector
+
+
+def main() -> None:
+    phonemizer = CRFOrthoCorrector()
+
+    sentences = [
+        "Muitas lhénguas ténen proua de ls sous pergaminos antigos.",
+        "Todos ls seres houmanos nácen lhibres i eiguales an honra i an dreitos.",
+        "Hai más fuogo alhá, i ye deimingo!",
+    ]
+    for text in sentences:
+        print("Original :", text)
+        print("IPA      :", phonemizer.phonemize_sentence(text))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_compare_engines.py
+++ b/examples/02_compare_engines.py
@@ -1,0 +1,34 @@
+"""Compare every dependency-free engine on the same Mirandese words.
+
+Run::
+
+    python examples/02_compare_engines.py
+"""
+from mwl_phonemizer import (
+    LookupTableMWL,
+    NgramMWLPhonemizer,
+    OrthographyRulesMWL,
+    CRFOrthoCorrector,
+)
+
+
+def main() -> None:
+    engines = [
+        LookupTableMWL(),
+        NgramMWLPhonemizer(n=4),
+        OrthographyRulesMWL(),
+        CRFOrthoCorrector(),
+    ]
+    words = ["lhéngua", "mirandesa", "houmanos", "fuogo"]
+
+    header = "engine".ljust(22) + "  ".join(w.ljust(12) for w in words)
+    print(header)
+    print("-" * len(header))
+    for eng in engines:
+        # lookup_word=False forces the engine path so the gold dict does not shadow it
+        cells = [eng.phonemize(w, lookup_word=False).ljust(12) for w in words]
+        print(type(eng).__name__.ljust(22) + "  ".join(cells))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_dialects.py
+++ b/examples/03_dialects.py
@@ -1,0 +1,21 @@
+"""Phonemize the same words under each Mirandese dialect.
+
+Run::
+
+    python examples/03_dialects.py
+"""
+from mwl_phonemizer import NgramMWLPhonemizer
+from mwl_phonemizer.base import Dialects
+
+
+def main() -> None:
+    words = ["lhéngua", "lhibres", "alhá"]
+
+    for dialect in (Dialects.CENTRAL, Dialects.RAIANO, Dialects.SENDINESE):
+        eng = NgramMWLPhonemizer(n=4, dialect=dialect)
+        transcriptions = [eng.phonemize(w, lookup_word=False) for w in words]
+        print(f"{dialect.value:10}", "  ".join(transcriptions))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_evaluate.py
+++ b/examples/04_evaluate.py
@@ -1,0 +1,31 @@
+"""Score an engine against the bundled gold dictionary and compute PER.
+
+Run::
+
+    python examples/04_evaluate.py
+"""
+from mwl_phonemizer import OrthographyRulesMWL
+
+
+def main() -> None:
+    eng = OrthographyRulesMWL()
+    stats = eng.evaluate_on_gold()
+
+    ref_len = sum(len(v) for v in eng.GOLD.values())
+    ref_len_ns = sum(len(eng.strip_stress(v)) for v in eng.GOLD.values())
+
+    per = stats["avg_edit_distance"] * stats["counts"] / ref_len
+    per_ns = stats["avg_edit_distance_no_stress"] * stats["counts"] / ref_len_ns
+
+    print(f"Words evaluated      : {stats['counts']}")
+    print(f"PER (stress)         : {per:.2%}")
+    print(f"PER (stress-agnostic): {per_ns:.2%}")
+    print(f"Words with errors    : {len(stats['details'])}")
+    print()
+    print(f"{'word':<14}{'gold':<16}{'got':<16}ed")
+    for d in stats["details"][:6]:
+        print(f"{d['word']:<14}{d['gold']:<16}{d['phonemes']:<16}{d['ed']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_clean_ipa.py
+++ b/examples/05_clean_ipa.py
@@ -1,0 +1,30 @@
+"""Normalise IPA output with the base-class marker and stress helpers.
+
+Run::
+
+    python examples/05_clean_ipa.py
+"""
+from mwl_phonemizer.base import MirandesePhonemizer
+
+
+def main() -> None:
+    samples = [
+        "ˈe(j).ʒɛmˈplu",
+        "miɾɐ̃ˈdes̺",
+        "ʎɛ̃ˈɡwɐ",
+    ]
+    print(f"{'raw':<16}{'no markers':<16}{'no stress':<16}")
+    for ipa in samples:
+        no_markers = MirandesePhonemizer.strip_markers(ipa)
+        no_stress = MirandesePhonemizer.strip_stress(ipa)
+        print(f"{ipa:<16}{no_markers:<16}{no_stress:<16}")
+
+    # The helpers compose — drop both syllable/optional markers and stress.
+    fully_clean = MirandesePhonemizer.strip_stress(
+        MirandesePhonemizer.strip_markers("ˈe(j).ʒɛmˈplu")
+    )
+    print("fully clean    :", fully_clean)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_train_custom_crf.py
+++ b/examples/06_train_custom_crf.py
@@ -1,0 +1,36 @@
+"""Train a character-level CRF on inline word/IPA pairs and predict with it.
+
+Run::
+
+    python examples/06_train_custom_crf.py
+"""
+from mwl_phonemizer import CRFPhonemizer
+from mwl_phonemizer.crf_mwl import AlignmentStrategy, align_with_lev
+
+
+def main() -> None:
+    # Tiny inline aligned dataset (orthography, gold IPA).
+    pairs = [
+        ("lhéngua", "ʎɛ̃ɡwɐ"),
+        ("mirandesa", "miɾɐ̃dezɐ"),
+        ("fuogo", "fwoɡu"),
+        ("alhá", "ɐʎa"),
+    ]
+
+    # Passing train_data trains immediately on those pairs instead of the gold dict.
+    eng = CRFPhonemizer(train_data=pairs, ignore_stress=True,
+                        strategy=AlignmentStrategy.LEV)
+    print("model trained:", eng.model is not None)
+
+    for word, gold in pairs:
+        got = eng.phonemize(word, lookup_word=False)
+        print(f"  {word:<12} gold={gold:<12} got={got}")
+
+    # The Levenshtein aligner the CRF trains on, shown directly.
+    inp, ref = align_with_lev("fuogo", "fwoɡu")
+    print("aligned input:", inp)
+    print("aligned gold :", ref)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a `docs/` directory and a `examples/` directory for the Mirandese phonemizers.

## docs/
- `quickstart.md` — install, the shared `phonemize`/`phonemize_sentence` interface, first call with `CRFOrthoCorrector`.
- `api.md` — every public class and signature: `MirandesePhonemizer` base, `LookupTableMWL`, `NgramMWLPhonemizer`, `OrthographyRulesMWL`, `CRFPhonemizer`, `CRFOrthoCorrector`, and the espeak/epitran backends.
- `advanced.md` — dialect selection, engine comparison, gold-dictionary evaluation and PER, custom CRF training, optional backends, gotchas.

## examples/
Six numbered runnable scripts, library public API plus stdlib only, inline Mirandese sample text, no network or external model files:
- `01_first_call.py` — sentence phonemization with `CRFOrthoCorrector`.
- `02_compare_engines.py` — same words across the dependency-free engines.
- `03_dialects.py` — Central / Raiano / Sendinese.
- `04_evaluate.py` — `evaluate_on_gold` and PER computation.
- `05_clean_ipa.py` — `strip_markers` / `strip_stress`.
- `06_train_custom_crf.py` — train a CRF on inline pairs and predict.

All six examples exit 0 against the shared environment.