### PR TITLE
refactor: build on the orthography2ipa shared lattice (tokenizer + rescorers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ This repository contains a Python-based Mirandese phonemizer, designed to conver
 
 -----
 
+## **Architecture**
+
+The rule-based engine (`OrthographyRulesMWL`) is built on the shared
+[orthography2ipa](https://github.com/TigreGotico/orthography2ipa) pronunciation
+lattice. Grapheme segmentation is delegated to the language-agnostic
+`orthography2ipa.phonetok.PhonetokTokenizer` (a maximal-munch trie over the
+Mirandese grapheme set declared in `g2p.json`) and every context-sensitive
+realisation rule (lenition, sibilant voicing, palatalisation, `i`/`u` glides,
+final `-o` raising, the trill/tap `r` split) runs as an
+`orthography2ipa.rescorer.LatticeRescorer` over the resulting per-grapheme
+`SegmentSlot` lattice. There is no private tokenizer and no hand-rolled index
+arithmetic — the engine shares the same segmentation substrate as every other
+orthography2ipa downstream (Barranquenho, arbtok, tugaphone).
+
+-----
+
 ## **Usage**
 
 ```python

--- a/docs/api.md
+++ b/docs/api.md
@@ -112,6 +112,12 @@ Hand-crafted orthographic and phonological rules (lenition, sibilant variation,
 Latin cluster evolution, palatalization). `keep_optional_phones` keeps phones the
 rules mark as optional (in parentheses); `keep_stress_marks` keeps `ˈ`/`ˌ`.
 
+Grapheme segmentation is delegated to the shared
+`orthography2ipa.phonetok.PhonetokTokenizer` (a maximal-munch trie over the
+Mirandese grapheme set) and the realisation rules run as an
+`orthography2ipa.rescorer.LatticeRescorer` over the resulting per-grapheme
+lattice — there is no private tokenizer or hand-rolled index arithmetic.
+
 ```python
 OrthographyRulesMWL().phonemize("lhéngua", lookup_word=False)   # 'ʎɛŋɡwa'
 ```

--- a/mwl_phonemizer/orthography_hand_rules.py
+++ b/mwl_phonemizer/orthography_hand_rules.py
@@ -1,5 +1,17 @@
-"""
-reference phonetic info from wikipedia:
+"""Rule-based Mirandese G2P built on the shared orthography2ipa lattice.
+
+Grapheme segmentation is delegated to the language-agnostic
+:class:`orthography2ipa.phonetok.PhonetokTokenizer` (a maximal-munch trie
+over the Mirandese grapheme set declared in ``g2p.json``) and every
+context-sensitive realisation rule runs as a
+:class:`orthography2ipa.rescorer.LatticeRescorer` re-costing the shared
+per-grapheme :class:`~orthography2ipa.phonetok.SegmentSlot` lattice. There
+is no private tokenizer and no hand-rolled index arithmetic: the bespoke
+``while i < len(word)`` scanner has been replaced by the shared trie plus a
+single rescorer that resolves each grapheme to its Mirandese realisation.
+
+Reference phonetic info (Wikipedia, "Mirandese language", drawing on Leite
+de Vasconcelos and the Convénçon Ortográfica da Lhéngua Mirandesa):
 
 # Ortography
 
@@ -88,13 +100,66 @@ As in Portuguese, Mirandese still uses the following synthetic tenses:
 
 """
 
-from collections import Counter
-from mwl_phonemizer.base import MirandesePhonemizer, Dialects
-
 import json
 import os.path
 import re
-import string
+from dataclasses import replace
+from functools import lru_cache
+
+from orthography2ipa import get
+from orthography2ipa.phonetok import (
+    PhonetokTokenizer, SegmentSlot, Candidate, TokenKind, flat_contexts,
+)
+from orthography2ipa.rescorer import LatticeRescorer, RescoreContext, apply_rescorers
+
+from mwl_phonemizer.base import MirandesePhonemizer, Dialects
+
+
+@lru_cache(maxsize=None)
+def _tokenizer(grapheme_key: tuple) -> PhonetokTokenizer:
+    """Shared maximal-munch tokenizer over the Mirandese grapheme set.
+
+    Built from the published ``mwl`` spec, but with the grapheme table
+    replaced by the local ``g2p.json`` inventory (passed in as a hashable
+    tuple of ``(grapheme, first-candidate)`` pairs) so segmentation stays
+    identical to the historical hand-rolled scanner while the trie itself
+    is the shared o2i one. Positional/allophone/weight branches are cleared
+    — this engine resolves realisation entirely through its own rescorer.
+    """
+    spec = get("mwl")
+    graphemes = {g: [ipa] for g, ipa in grapheme_key}
+    narrowed = replace(
+        spec,
+        graphemes=graphemes,
+        positional_graphemes=None,
+        allophones={},
+        grapheme_weights=None,
+        allophone_rules=None,
+        sandhi_rules=None,
+        word_exceptions=None,
+    )
+    return PhonetokTokenizer(narrowed)
+
+
+class _MirandeseRescorer(LatticeRescorer):
+    """Resolve each Mirandese grapheme to its realisation over the shared
+    lattice.
+
+    A thin adapter around :meth:`OrthographyRulesMWL._grapheme_ipa`: it reads
+    the slot's grapheme and its character offset (``slot.span[0]``) and asks
+    the owning phonemizer for the context-conditioned IPA. Keeping the rule
+    body on the phonemizer lets every rule consult the full source word
+    (``owner._word``) and the ``g2p.json`` candidate table, exactly as the
+    historical scanner did — the migration changes *where* segmentation and
+    rescoring happen (the shared trie + B4 seam), not the phonology.
+    """
+
+    def __init__(self, owner: "OrthographyRulesMWL"):
+        self._owner = owner
+
+    def rescore(self, slot: SegmentSlot, ctx: RescoreContext):
+        ipa = self._owner._grapheme_ipa(slot.grapheme, slot.span[0])
+        return (Candidate(ipa, 0.0),)
 
 
 class OrthographyRulesMWL(MirandesePhonemizer):
@@ -108,6 +173,16 @@ class OrthographyRulesMWL(MirandesePhonemizer):
         self._voiced_consonants = "bdgjlmnrvz"  # Approximated list of voiced consonants
         with open(os.path.join(os.path.dirname(__file__), "g2p.json")) as f:
             self.MWL_ALPHABET_MAP = json.load(f)
+        # source word currently being phonemized (read by the rescorer's
+        # char-level context rules; the shared lattice slots carry the
+        # absolute char offsets that index back into it)
+        self._word = ""
+        self._rescorers = (_MirandeseRescorer(self),)
+
+    @property
+    def _tok(self) -> PhonetokTokenizer:
+        key = tuple((g, cands[0]) for g, cands in self.MWL_ALPHABET_MAP.items())
+        return _tokenizer(key)
 
     def _is_vowel(self, char):
         """Checks if a character is a vowel."""
@@ -135,227 +210,233 @@ class OrthographyRulesMWL(MirandesePhonemizer):
             phonemized = re.sub(r'\([^)]*\)', '', phonemized)
         return phonemized
 
-    def phonemize_word(self, word: str):
-        """
-        Phonemizes a single Mirandese word based on the provided mapping and rules,
-        with support for dialectal variations.
+    def _grapheme_ipa(self, grapheme: str, i: int) -> str:
+        """Return the IPA realisation of *grapheme* starting at char offset *i*.
 
-        Args:
-            word (str): The word to phonemize..
+        Pure per-grapheme rule body invoked through the lattice rescorer. It
+        reads the source word from ``self._word`` (so word-local context —
+        ``word[i-1]`` / ``word[i+1]`` — is exactly what the historical
+        scanner used) and selects among the ``g2p.json`` candidates.
+        """
+        word = self._word
+        length = len(grapheme)
+
+        # Dialectal variation for 'l' / 'lh' (Sendinese de-palatalisation):
+        # Sendinese says [l] where other variants say [ʎ] ⟨lh⟩, and keeps a
+        # word-initial ⟨l⟩ as [l] (Wikipedia: alá/alhá, lado/lhado, luç/lhuç).
+        if self.dialect == Dialects.SENDINESE:
+            if grapheme == "lh":
+                return self.MWL_ALPHABET_MAP["l"][0]  # 'lh' becomes [l] in Sendinese
+            elif grapheme == "l" and i == 0:  # Initial 'l' in Sendinese remains [l]
+                return self.MWL_ALPHABET_MAP["l"][0]
+
+        if grapheme == "b":
+            # Rule: b = [β] between vowels and after voiced consonants
+            if (i > 0 and self._is_vowel(word[i - 1])) and \
+                    (i + 1 < len(word) and self._is_vowel(word[i + 1])):
+                return self.MWL_ALPHABET_MAP["b"][1]  # [β] between vowels
+            elif i > 0 and self._is_voiced_consonant(word[i - 1]):
+                return self.MWL_ALPHABET_MAP["b"][1]  # [β] after voiced consonants
+            else:
+                return self.MWL_ALPHABET_MAP["b"][0]  # [b] otherwise
+        elif grapheme == "c":
+            # Rule: c = [s̻] before e or i, [k] elsewhere
+            if (i + 1 < len(word) and word[i + 1].lower() in "ei"):
+                return self.MWL_ALPHABET_MAP["c"][1]  # [s̻] before e or i (second element in map)
+            else:
+                return self.MWL_ALPHABET_MAP["c"][0]  # [k] elsewhere (first element in map)
+        elif grapheme == "ç":
+            # Rule: ç = [z̻] before words starting with voiced consonants
+            # This rule is tricky without full word context (e.g., "words starting with voiced consonants")
+            # For now, a simplified interpretation: if followed by a voiced consonant within the word.
+            # A more accurate implementation would require sentence-level context.
+            if i + 1 < len(word) and self._is_voiced_consonant(word[i + 1]):
+                return self.MWL_ALPHABET_MAP["ç"][0]  # [z̻]
+            else:
+                return self.MWL_ALPHABET_MAP["ç"][0]  # Default to [z̻]
+        elif grapheme == "d":
+            # Rule: d = [ð] between vowels and after r
+            if (i > 0 and self._is_vowel(word[i - 1])) and \
+                    (i + 1 < len(word) and self._is_vowel(word[i + 1])):
+                return self.MWL_ALPHABET_MAP["d"][1]  # [ð] between vowels
+            elif i > 0 and word[i - 1].lower() == 'r':
+                return self.MWL_ALPHABET_MAP["d"][1]  # [ð] after r
+            else:
+                return self.MWL_ALPHABET_MAP["d"][0]  # [d] otherwise
+        elif grapheme == "e":
+            # Rule: e = [ɨ/ɨ̃] before stressed syllables
+            # This rule requires stress prediction, which is beyond this rule-based phonemizer.
+            # Defaulting to the first phoneme [e].
+            return self.MWL_ALPHABET_MAP["e"][0]
+        elif grapheme == "g":
+            # Rule: g = [ɣ] between vowels and after r. Before e and i, g = [ʒ].
+            # g = [ɡu] in certain words, such as guira, guiron and guirica. g = [gu̯] before a
+            if (i > 0 and self._is_vowel(word[i - 1])) and \
+                    (i + 1 < len(word) and self._is_vowel(word[i + 1])):
+                return self.MWL_ALPHABET_MAP["g"][1]  # [ɣ] between vowels
+            elif i > 0 and word[i - 1].lower() == 'r':
+                return self.MWL_ALPHABET_MAP["g"][1]  # [ɣ] after r
+            elif (i + 1 < len(word) and word[i + 1].lower() in "ei"):
+                return self.MWL_ALPHABET_MAP["g"][2]  # [ʒ] before e and i
+            # The [ɡu] and [gu̯] rules are word-specific and complex for a simple rule-based system.
+            # Defaulting to [g] for other cases.
+            else:
+                return self.MWL_ALPHABET_MAP["g"][0]
+        elif grapheme == "gu":
+            # Rule: gu = [ɣ] between vowels and after r
+            # Simplified: checking context around 'gu'
+            if (i > 0 and self._is_vowel(word[i - 1])) and \
+                    (i + 2 < len(word) and self._is_vowel(word[i + 2])):  # Check the character *after* 'u'
+                return self.MWL_ALPHABET_MAP["gu"][2]  # [ɣ] between vowels (third element in map)
+            elif i > 0 and word[i - 1].lower() == 'r':
+                return self.MWL_ALPHABET_MAP["gu"][2]  # [ɣ] after r
+            else:
+                return self.MWL_ALPHABET_MAP["gu"][0]  # [g] otherwise (first element in map)
+        elif grapheme == "i":
+            # Rule: i can become glide [j] when preceding or following other vowels.
+            is_glide = False
+            # Check if 'i' is followed by a vowel
+            if i + 1 < len(word) and self._is_vowel(word[i + 1]):
+                is_glide = True
+            # Check if 'i' is preceded by a vowel
+            elif i > 0 and self._is_vowel(word[i - 1]):
+                is_glide = True
+
+            if is_glide:
+                return self.MWL_ALPHABET_MAP["i"][1]  # [j]
+            else:
+                return self.MWL_ALPHABET_MAP["i"][0]  # [i]
+        elif grapheme == "l":
+            # This rule is now handled by the dialect-specific check above for 'sendinese'
+            if self.dialect != Dialects.SENDINESE and i == 0:
+                return self.MWL_ALPHABET_MAP["l"][1]  # [ʎ] at the beginning of words (non-Sendinese)
+            else:
+                return self.MWL_ALPHABET_MAP["l"][0]  # [l] elsewhere
+        elif grapheme == "lh":
+            # This rule is now handled by the dialect-specific check above for 'sendinese'
+            # (non-Sendinese only reaches here)
+            return self.MWL_ALPHABET_MAP["lh"][0]  # [ʎ] for 'lh' (non-Sendinese)
+        elif grapheme == "m":
+            # Rule: m is silent before nasalized front vowels, e.g. amportante
+            # Default to [m]. Nasalization of preceding vowels is handled by AN, EN, IN, ON, UN.
+            return self.MWL_ALPHABET_MAP["m"][0]  # [m]
+        elif grapheme == "n":
+            # Rule: n = [ŋ] before k, g, q (velar consonants), otherwise [n].
+            # Nasalization of preceding vowels is handled by AN, EN, IN, ON, UN.
+            if i + 1 < len(word) and word[i + 1].lower() in "kgq":
+                return self.MWL_ALPHABET_MAP["n"][1]  # [ŋ]
+            else:
+                return self.MWL_ALPHABET_MAP["n"][0]  # [n]
+        elif grapheme == "o":
+            # Rule: o = [u] when unstressed. Also, final -o becomes /u/.
+            if i == len(word) - 1:  # If 'o' is the last character in the word
+                return self.MWL_ALPHABET_MAP["o"][2]  # [u] (third element in map)
+            # This rule requires stress prediction, which is beyond this rule-based phonemizer.
+            # Defaulting to the first phoneme [ɔ] for non-final 'o'.
+            else:
+                return self.MWL_ALPHABET_MAP["o"][0]
+        elif grapheme == "qu":
+            # Rule: qu = [k] before e and i, and [kṷ] before a and en
+            if (i + 2 < len(word) and word[i + 2].lower() in "ei"):
+                return self.MWL_ALPHABET_MAP["qu"][0]  # [k] before e and i
+            elif (i + 2 < len(word) and word[i + 2].lower() == "a") or \
+                    (i + 2 < len(word) - 1 and word[i + 2:i + 4].lower() == "en"):
+                return self.MWL_ALPHABET_MAP["qu"][1]  # [kṷ] before a or en
+            else:
+                return self.MWL_ALPHABET_MAP["qu"][0]  # default to [k]
+        elif grapheme == "r":
+            # Rule: r = [rr] at the beginning of words and after n
+            # The "hard" or "long" R is an alveolar trill /r/. The "soft" or "short" R is an alveolar tap [ɾ].
+            # The map has ["ɾ", "r", "rr"]. So "r" is the trill, "ɾ" is the tap.
+            if i == 0 or (i > 0 and word[i - 1].lower() == 'n'):  # At beginning or after n
+                return self.MWL_ALPHABET_MAP["r"][1]  # [r] (second element in map, the trill)
+            else:
+                return self.MWL_ALPHABET_MAP["r"][0]  # [ɾ] elsewhere (first element in map, the tap)
+        elif grapheme == "s":
+            # Rule: s = [s̺] when in initial position and before silent consonants.
+            # Between vowels and before voiced consonants, s = [z̺]
+            if i == 0 or (i + 1 < len(word) and not self._is_vowel(
+                    word[i + 1])):  # Initial or before non-vowel (simplified 'silent consonant')
+                return self.MWL_ALPHABET_MAP["s"][0]  # [s̺]
+            elif (i > 0 and self._is_vowel(word[i - 1])) and \
+                    (i + 1 < len(word) and self._is_voiced_consonant(word[i + 1])):
+                return self.MWL_ALPHABET_MAP["s"][1]  # [z̺] between vowels and before voiced consonants
+            elif (i > 0 and self._is_vowel(word[i - 1])) and \
+                    (i + 1 < len(word) and self._is_vowel(word[i + 1])):
+                return self.MWL_ALPHABET_MAP["s"][1]  # [z̺] between vowels
+            else:
+                return self.MWL_ALPHABET_MAP["s"][0]  # Default [s̺]
+        elif grapheme == "u":
+            # Rule: u can become glide [w] when preceding or following other vowels.
+            is_glide = False
+            # Check if 'u' is followed by a vowel
+            if i + 1 < len(word) and self._is_vowel(word[i + 1]):
+                is_glide = True
+            # Check if 'u' is preceded by a vowel
+            elif i > 0 and self._is_vowel(word[i - 1]):
+                is_glide = True
+
+            if is_glide:
+                return self.MWL_ALPHABET_MAP["u"][1]  # [w]
+            else:
+                return self.MWL_ALPHABET_MAP["u"][0]  # [u]
+        elif grapheme == "v":
+            return self.MWL_ALPHABET_MAP["v"][0]
+        elif grapheme == "w":
+            return self.MWL_ALPHABET_MAP["w"][0]
+        elif grapheme in ["pl", "kl", "fl", "mn", "ly", "cl", "ll", "nn"]:
+            return self.MWL_ALPHABET_MAP[grapheme][0]
+        elif grapheme in self.MWL_ALPHABET_MAP:
+            # For other graphemes, take the first phoneme in the list as default
+            return self.MWL_ALPHABET_MAP[grapheme][0]
+        # Fallback for any unmapped character (kept as-is, e.g. bare 'ê')
+        return grapheme
+
+    def phonemize_word(self, word: str):
+        """Phonemize a single Mirandese word over the shared o2i lattice.
+
+        Segmentation is delegated to the shared
+        :class:`~orthography2ipa.phonetok.PhonetokTokenizer`; the Mirandese
+        realisation rules run as a :class:`~orthography2ipa.rescorer.LatticeRescorer`
+        over the resulting per-grapheme slots. Characters the trie does not
+        recognise (e.g. a bare ⟨ê⟩) are passed through unchanged, as before.
         """
         word = word.lower()
         if word == "l":
             return "l̩"
 
-        phonemes = []
-        i = 0
-        while i < len(word):
-            matched = False
+        self._word = word
+        tokens = self._tok.tokenize(word)
 
-            # Try to match multi-character graphemes first (longest first)
-            # This ensures 'ch' is matched before 'c', 'lh' before 'l', etc.
-            # Also handles new clusters like 'pl', 'kl', 'fl', 'mn', 'ly', 'cl', 'll', 'nn'
-            for length in sorted([len(g) for g in self.MWL_ALPHABET_MAP.keys()], reverse=True):
-                if i + length <= len(word):
-                    grapheme = word[i:i + length].lower()
+        # grapheme slots -> rescore over the shared lattice
+        g_tokens = [t for t in tokens if t.kind == TokenKind.GRAPHEME]
+        contexts = flat_contexts(g_tokens)
+        slots = [
+            SegmentSlot(
+                grapheme=t.grapheme,
+                span=(t.position, t.position + t.length),
+                candidates=(Candidate(self.MWL_ALPHABET_MAP.get(t.grapheme, [t.grapheme])[0], 0.0),),
+            )
+            for t in g_tokens
+        ]
+        rescored = apply_rescorers(
+            slots, contexts, self._rescorers,
+            syll_for_token=list(range(len(g_tokens))),
+            stressed_syll_idx=None,
+        )
 
-                    # Handle dialectal variations for 'l' and 'lh'
-                    if self.dialect == Dialects.SENDINESE:
-                        if grapheme == "lh":
-                            phonemes.append(self.MWL_ALPHABET_MAP["l"][0])  # 'lh' becomes [l] in Sendinese
-                            i += length
-                            matched = True
-                            break
-                        elif grapheme == "l" and i == 0:  # Initial 'l' in Sendinese remains [l]
-                            phonemes.append(self.MWL_ALPHABET_MAP["l"][0])
-                            i += length
-                            matched = True
-                            break
-
-                    if grapheme in self.MWL_ALPHABET_MAP:
-                        # Apply specific rules for graphemes based on context
-                        if grapheme == "b":
-                            # Rule: b = [β] between vowels and after voiced consonants
-                            if (i > 0 and self._is_vowel(word[i - 1])) and \
-                                    (i + 1 < len(word) and self._is_vowel(word[i + 1])):
-                                phonemes.append(self.MWL_ALPHABET_MAP["b"][1])  # [β] between vowels
-                            elif i > 0 and self._is_voiced_consonant(word[i - 1]):
-                                phonemes.append(self.MWL_ALPHABET_MAP["b"][1])  # [β] after voiced consonants
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["b"][0])  # [b] otherwise
-                        elif grapheme == "c":
-                            # Rule: c = [s̻] before e or i, [k] elsewhere
-                            if (i + 1 < len(word) and word[i + 1].lower() in "ei"):
-                                phonemes.append(self.MWL_ALPHABET_MAP["c"][1])  # [s̻] before e or i (second element in map)
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["c"][0])  # [k] elsewhere (first element in map)
-                        elif grapheme == "ç":
-                            # Rule: ç = [z̻] before words starting with voiced consonants
-                            # This rule is tricky without full word context (e.g., "words starting with voiced consonants")
-                            # For now, a simplified interpretation: if followed by a voiced consonant within the word.
-                            # A more accurate implementation would require sentence-level context.
-                            if i + 1 < len(word) and self._is_voiced_consonant(word[i + 1]):
-                                phonemes.append(self.MWL_ALPHABET_MAP["ç"][0])  # [z̻]
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["ç"][0])  # Default to [z̻]
-                        elif grapheme == "d":
-                            # Rule: d = [ð] between vowels and after r
-                            if (i > 0 and self._is_vowel(word[i - 1])) and \
-                                    (i + 1 < len(word) and self._is_vowel(word[i + 1])):
-                                phonemes.append(self.MWL_ALPHABET_MAP["d"][1])  # [ð] between vowels
-                            elif i > 0 and word[i - 1].lower() == 'r':
-                                phonemes.append(self.MWL_ALPHABET_MAP["d"][1])  # [ð] after r
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["d"][0])  # [d] otherwise
-                        elif grapheme == "e":
-                            # Rule: e = [ɨ/ɨ̃] before stressed syllables
-                            # This rule requires stress prediction, which is beyond this rule-based phonemizer.
-                            # Defaulting to the first phoneme [e].
-                            phonemes.append(self.MWL_ALPHABET_MAP["e"][0])
-                        elif grapheme == "g":
-                            # Rule: g = [ɣ] between vowels and after r. Before e and i, g = [ʒ].
-                            # g = [ɡu] in certain words, such as guira, guiron and guirica. g = [gu̯] before a
-                            if (i > 0 and self._is_vowel(word[i - 1])) and \
-                                    (i + 1 < len(word) and self._is_vowel(word[i + 1])):
-                                phonemes.append(self.MWL_ALPHABET_MAP["g"][1])  # [ɣ] between vowels
-                            elif i > 0 and word[i - 1].lower() == 'r':
-                                phonemes.append(self.MWL_ALPHABET_MAP["g"][1])  # [ɣ] after r
-                            elif (i + 1 < len(word) and word[i + 1].lower() in "ei"):
-                                phonemes.append(self.MWL_ALPHABET_MAP["g"][2])  # [ʒ] before e and i
-                            # The [ɡu] and [gu̯] rules are word-specific and complex for a simple rule-based system.
-                            # Defaulting to [g] for other cases.
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["g"][0])
-                        elif grapheme == "gu":
-                            # Rule: gu = [ɣ] between vowels and after r
-                            # Simplified: checking context around 'gu'
-                            if (i > 0 and self._is_vowel(word[i - 1])) and \
-                                    (i + 2 < len(word) and self._is_vowel(
-                                        word[i + 2])):  # Check the character *after* 'u'
-                                phonemes.append(self.MWL_ALPHABET_MAP["gu"][2])  # [ɣ] between vowels (third element in map)
-                            elif i > 0 and word[i - 1].lower() == 'r':
-                                phonemes.append(self.MWL_ALPHABET_MAP["gu"][2])  # [ɣ] after r
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["gu"][0])  # [g] otherwise (first element in map)
-                        elif grapheme == "i":
-                            # Rule: i can become glide [j] when preceding or following other vowels.
-                            is_glide = False
-                            # Check if 'i' is followed by a vowel
-                            if i + 1 < len(word) and self._is_vowel(word[i + 1]):
-                                is_glide = True
-                            # Check if 'i' is preceded by a vowel
-                            elif i > 0 and self._is_vowel(word[i - 1]):
-                                is_glide = True
-
-                            if is_glide:
-                                phonemes.append(self.MWL_ALPHABET_MAP["i"][1])  # [j]
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["i"][0])  # [i]
-                        elif grapheme == "l":
-                            # This rule is now handled by the dialect-specific check above for 'sendinese'
-                            if self.dialect != Dialects.SENDINESE and i == 0:
-                                phonemes.append(
-                                    self.MWL_ALPHABET_MAP["l"][1])  # [ʎ] at the beginning of words (non-Sendinese)
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["l"][0])  # [l] elsewhere
-                        elif grapheme == "lh":
-                            # This rule is now handled by the dialect-specific check above for 'sendinese'
-                            if self.dialect != Dialects.SENDINESE:
-                                phonemes.append(self.MWL_ALPHABET_MAP["lh"][0])  # [ʎ] for 'lh' (non-Sendinese)
-                            # else: handled by the 'sendinese' block above
-                        elif grapheme == "m":
-                            # Rule: m is silent before nasalized front vowels, e.g. amportante
-                            # Default to [m]. Nasalization of preceding vowels is handled by AN, EN, IN, ON, UN.
-                            phonemes.append(self.MWL_ALPHABET_MAP["m"][0])  # [m]
-                        elif grapheme == "n":
-                            # Rule: n = [ŋ] before k, g, q (velar consonants), otherwise [n].
-                            # Nasalization of preceding vowels is handled by AN, EN, IN, ON, UN.
-                            if i + 1 < len(word) and word[i + 1].lower() in "kgq":
-                                phonemes.append(self.MWL_ALPHABET_MAP["n"][1])  # [ŋ]
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["n"][0])  # [n]
-                        elif grapheme == "o":
-                            # Rule: o = [u] when unstressed. Also, final -o becomes /u/.
-                            if i == len(word) - 1:  # If 'o' is the last character in the word
-                                phonemes.append(self.MWL_ALPHABET_MAP["o"][2])  # [u] (third element in map)
-                            # This rule requires stress prediction, which is beyond this rule-based phonemizer.
-                            # Defaulting to the first phoneme [ɔ] for non-final 'o'.
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["o"][0])
-                        elif grapheme == "qu":
-                            # Rule: qu = [k] before e and i, and [kṷ] before a and en
-                            if (i + 2 < len(word) and word[i + 2].lower() in "ei"):
-                                phonemes.append(self.MWL_ALPHABET_MAP["qu"][0])  # [k] before e and i
-                            elif (i + 2 < len(word) and word[i + 2].lower() == "a") or \
-                                    (i + 2 < len(word) - 1 and word[i + 2:i + 4].lower() == "en"):
-                                phonemes.append(self.MWL_ALPHABET_MAP["qu"][1])  # [kṷ] before a or en
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["qu"][0])  # default to [k]
-                        elif grapheme == "r":
-                            # Rule: r = [rr] at the beginning of words and after n
-                            # The "hard" or "long" R is an alveolar trill /r/. The "soft" or "short" R is an alveolar tap [ɾ].
-                            # The map has ["ɾ", "r", "rr"]. So "r" is the trill, "ɾ" is the tap.
-                            if i == 0 or (i > 0 and word[i - 1].lower() == 'n'):  # At beginning or after n
-                                phonemes.append(self.MWL_ALPHABET_MAP["r"][1])  # [r] (second element in map, the trill)
-                            else:
-                                phonemes.append(
-                                    self.MWL_ALPHABET_MAP["r"][0])  # [ɾ] elsewhere (first element in map, the tap)
-                        elif grapheme == "s":
-                            # Rule: s = [s̺] when in initial position and before silent consonants.
-                            # Between vowels and before voiced consonants, s = [z̺]
-                            if i == 0 or (i + 1 < len(word) and not self._is_vowel(
-                                    word[i + 1])):  # Initial or before non-vowel (simplified 'silent consonant')
-                                phonemes.append(self.MWL_ALPHABET_MAP["s"][0])  # [s̺]
-                            elif (i > 0 and self._is_vowel(word[i - 1])) and \
-                                    (i + 1 < len(word) and self._is_voiced_consonant(word[i + 1])):
-                                phonemes.append(
-                                    self.MWL_ALPHABET_MAP["s"][1])  # [z̺] between vowels and before voiced consonants
-                            elif (i > 0 and self._is_vowel(word[i - 1])) and \
-                                    (i + 1 < len(word) and self._is_vowel(word[i + 1])):
-                                phonemes.append(self.MWL_ALPHABET_MAP["s"][1])  # [z̺] between vowels
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["s"][0])  # Default [s̺]
-                        elif grapheme == "u":
-                            # Rule: u can become glide [w] when preceding or following other vowels.
-                            is_glide = False
-                            # Check if 'u' is followed by a vowel
-                            if i + 1 < len(word) and self._is_vowel(word[i + 1]):
-                                is_glide = True
-                            # Check if 'u' is preceded by a vowel
-                            elif i > 0 and self._is_vowel(word[i - 1]):
-                                is_glide = True
-
-                            if is_glide:
-                                phonemes.append(self.MWL_ALPHABET_MAP["u"][1])  # [w]
-                            else:
-                                phonemes.append(self.MWL_ALPHABET_MAP["u"][0])  # [u]
-                        # For v and w, the map has multiple options, but Wikipedia implies primarily for loanwords.
-                        # Sticking to the first phoneme in the map as default for simplicity.
-                        elif grapheme == "v":
-                            phonemes.append(self.MWL_ALPHABET_MAP["v"][0])
-                        elif grapheme == "w":
-                            phonemes.append(self.MWL_ALPHABET_MAP["w"][0])
-                        # --- cluster rules ---
-                        elif grapheme in ["pl", "kl", "fl", "mn", "ly", "cl", "ll", "nn"]:
-                            phonemes.append(self.MWL_ALPHABET_MAP[grapheme][0])
-                        else:
-                            # For other graphemes, take the first phoneme in the list as default
-                            phonemes.append(self.MWL_ALPHABET_MAP[grapheme][0])
-
-                        i += length
-                        matched = True
-                        break  # Break from the inner loop (grapheme lengths) once a match is found
-
-            # If no multi-character grapheme matched, try single character
-            if not matched:
-                if word[i].lower() in self.MWL_ALPHABET_MAP:
-                    phonemes.append(self.MWL_ALPHABET_MAP[word[i].lower()][0])
-                elif word[i] in string.punctuation + string.whitespace:
-                    phonemes.append(word[i])  # Keep punctuation as is
-                else:
-                    phonemes.append(word[i])  # Fallback for any unmapped character
-                i += 1
-        phonemized = "".join(phonemes)
+        # stitch grapheme IPA back together in surface order, passing
+        # non-grapheme (unrecognised) tokens through unchanged
+        rescored_iter = iter(rescored)
+        parts = []
+        for t in tokens:
+            if t.kind == TokenKind.GRAPHEME:
+                s = next(rescored_iter)
+                if s.candidates and s.top.ipa:
+                    parts.append(s.top.ipa)
+            else:
+                parts.append(t.grapheme)
+        phonemized = "".join(parts)
         return self._post_process(phonemized)
 
     def phonemize_sentence(self,  text: str):
@@ -374,7 +455,7 @@ class OrthographyRulesMWL(MirandesePhonemizer):
     # Phonemizer interface
     # -------------------------
     def phonemize(self, word: str, lookup_word: bool = True) -> str:
-        """Phonemize a single Mirandese word via espeak + correction rules."""
+        """Phonemize a single Mirandese word via the lattice + correction rules."""
         if lookup_word and word.lower() in self.GOLD:
             return self.GOLD[word.lower()]
         return self.phonemize_word(word)
@@ -386,11 +467,9 @@ if __name__ == "__main__":
 
     stats = pho.evaluate_on_gold(limit=None, detailed=False, show_changes=False)
 
-    # PER is computed inside evaluate_on_gold (see base.MirandesePhonemizer).
     per = stats['per']
     per_no_stress = stats['per_no_stress']
 
-    # --- Print Summary Metrics ---
     print("\n" + "=" * 50)
     print("      Mirandese Phonemizer Rule Evaluation")
     print("=" * 50)
@@ -402,173 +481,15 @@ if __name__ == "__main__":
     print("\n## Phoneme Error Rate (PER, Stress-Agnostic)")
     print(f"PER:    {per_no_stress:.2%}")
 
-    # --- Print only 'wrong' words (ED > 0) ---
     print("\n--- Incorrectly Phonemized Words (Full IPA Match ED > 0) ---")
     wrong_words = stats.get("details", [])
 
     if wrong_words:
         print(f"Total Incorrect: {len(wrong_words)} words\n")
-
-        # Print a header for the detailed list
         print(f"{'Word':<20} | {'Gold':<15} | {'Phonemized':<15} | {'ED After':<8}")
         print("-" * 75)
-
-        # Print the detailed list
         for d in wrong_words:
             print(
                 f"{d['word']:<20} | {d['gold']:<15} | {d['phonemes']:<15} | {d['ed']:<8}")
     else:
         print("All words achieved an exact match (100% Accuracy)!")
-
-    # ==================================================
-    #       Mirandese Phonemizer Orthography Rules Evaluation
-    # ==================================================
-    # Total Words Evaluated: 145
-    #
-    # ## Phoneme Error Rate (PER, Full IPA Match, includes stress)
-    # PER:    39.04%
-    #
-    # ## Phoneme Error Rate (PER, Stress-Agnostic)
-    # PER:    31.99%
-    #
-    # --- Incorrectly Phonemized Words (Full IPA Match ED > 0) ---
-    # Total Incorrect: 136 words
-    #
-    # Word                 | Gold            | Phonemized      | ED After
-    # ---------------------------------------------------------------------------
-    # más                  | mas̺            | mɐ̃s̺           | 2
-    # alhá                 | ɐˈʎa            | aʎɐ̃            | 4
-    # deimingo             | dejˈmĩgʊ        | dejmĩŋgu        | 3
-    # abandono             | abɐ̃ˈdonu       | abɐ̃dõŋu        | 3
-    # adbertido            | ɐdbɨɾˈtidu      | adβeɾtiðu       | 5
-    # adulto               | ɐˈdultu         | aðultu          | 3
-    # afamado              | ɐfɐˈmadu        | afɐ̃ŋaðu        | 4
-    # afeito               | ɐˈfejtʊ         | afejtu          | 3
-    # afelhado             | ɐfɨˈʎadu        | afɨʎaðu         | 3
-    # alternatibo          | altɨɾnɐˈtibu    | alteɾnatiβu     | 4
-    # amarielho            | ɐmɐˈɾjɛʎu       | ɐ̃ŋaɾjeʎu       | 4
-    # ambesible            | ɐ̃bɨˈs̺iblɨ     | ɐ̃ŋβɨz̺iblɨ     | 4
-    # amouchado            | amowˈtʃaðu      | ɐ̃ŋowtʃaðu      | 4
-    # amportante           | ɐ̃puɾˈtɐ̃tɨ     | ɐ̃ŋpɔɾtɐ̃ŋte    | 5
-    # ampossible           | ɐ̃puˈsiblɨ      | ɐ̃ŋpɔs̺iblɨ     | 4
-    # ampressionante       | ɐ̃pɾɨsjuˈnɐ̃tɨ  | ɐ̃ŋpɾes̺jõŋɐ̃ŋte | 8
-    # anchir               | ɐ̃ˈtʃiɾ         | ɐ̃ŋtʃiɾ         | 1
-    # antender             | ɐ̃tɨ̃ˈdeɾ       | ɐ̃ŋtẽŋdeɾ       | 4
-    # arena                | ɐˈɾenɐ          | aɾẽŋa           | 5
-    # açpuis               | ɐsˈpujs̺        | ɐspujs̺         | 1
-    # berde                | ˈveɾdɨ          | beɾðe           | 4
-    # besible              | bɨˈz̺iblɨ       | bɨz̺iblɨ        | 1
-    # bexanar              | bɨʃɐˈnaɾ        | beʃɐ̃ŋaɾ        | 3
-    # bibal                | biˈβaɫ          | biβal           | 2
-    # bielho               | bjɛʎu           | bjeʎu           | 1
-    # biolento             | bjuˈlẽtu        | bjɔlẽŋtu        | 3
-    # biúba                | biˈuβɐ          | bjuβa           | 3
-    # brabo                | bɾabu           | bɾaβu           | 1
-    # burmeilho            | buɾˈmɐjʎu       | buɾmejʎu        | 2
-    # cabresto             | kɐˈbɾeʃtu       | kabɾeʃtu        | 2
-    # canhona              | kɐˈɲonɐ         | kɐ̃ŋõŋa         | 5
-    # cheno                | ˈtʃenu          | tʃenu           | 1
-    # chober               | tʃuˈβeɾ         | tʃuβeɾ          | 1
-    # ciguonha             | s̻iˈɣwoɲɐ       | s̻iɣwoɲa        | 2
-    # dafeito              | ðɐˈfejtʊ        | dafejtu         | 4
-    # defrente             | dɨˈfɾẽtɨ        | defɾẽŋte        | 4
-    # defícel              | dɨˈfisɛl        | defis̻el        | 4
-    # drento               | ˈdɾẽtu          | dɾẽŋtu          | 2
-    # eigual               | ɐjˈɡwal         | ejɡwal          | 2
-    # era                  | ˈɛɾɐ            | eɾa             | 3
-    # eras                 | ˈɛɾɐs̺          | eɾas̺           | 3
-    # feliç                | fɨˈlis̻         | fɨlis̻          | 1
-    # fierro               | ˈfjɛru          | fjɛru           | 1
-    # francesa             | fɾɐ̃ˈsɛzɐ       | fɾɐ̃ŋs̻ez̺a     | 5
-    # francesas            | fɾɐ̃ˈsɛzɐs̺     | fɾɐ̃ŋs̻ezɐs̺    | 3
-    # franceses            | fɾɐ̃ˈsɛzɨs̺     | fɾɐ̃ŋs̻ezɨs̺    | 3
-    # francés              | fɾɐ̃ˈsɛs̺       | fɾɐ̃ŋsɛs        | 2
-    # fumos                | ˈfumus̺         | fumus̺          | 1
-    # fuogo                | fwoɣʊ           | fwoɣu           | 1
-    # fuonte               | ˈfwõtɨ          | fwonte          | 4
-    # fuorte               | ˈfwɔɾtɨ         | fwɔɾte          | 2
-    # fuortemente          | fwɔɾtɨˈmẽtɨ     | fwɔɾtemẽte      | 3
-    # fuorça               | ˈfwɔɾs̻ɐ        | fwɔɾz̻a         | 3
-    # fuste                | ˈfus̺tɨ         | fus̺te          | 2
-    # fácele               | ˈfasɨlɨ         | fɐ̃s̻ele        | 6
-    # guapo                | ˈɡwapu          | ɡwapu           | 1
-    # haber                | ɐˈβeɾ           | aβeɾ            | 2
-    # houmano              | owˈmɐnu         | owmɐ̃ŋu         | 3
-    # l                    | l̩              | ʎ               | 2
-    # lhabrar              | ʎɐˈbɾaɾi        | ʎabɾaɾ          | 3
-    # lhimpo               | ˈʎĩpʊ           | ʎimpu           | 4
-    # lhobo                | ˈʎobʊ           | ʎɔβu            | 4
-    # lhuç                 | ˈʎus̻           | ʎuz̻            | 2
-    # lhéngua              | ˈʎɛ̃ɡwɐ         | ʎɛŋɡwa          | 3
-    # luç                  | ˈʎus̻           | ʎuz̻            | 2
-    # macado               | mɐˈkadu         | makaðu          | 3
-    # maias                | ˈmajɐs̺         | majas̺          | 2
-    # mirandés             | miɾɐ̃ˈdes̺      | miɾɐ̃ŋdɛs̺      | 2
-    # molineiro            | mʊliˈnei̯rʊ     | mɔlĩŋejɾu       | 8
-    # molino               | muˈlinu         | mɔlĩŋu          | 4
-    # muola                | ˈmu̯olɐ         | mwola           | 4
-    # ne l                 | nɨl             | ne ʎ            | 3
-    # neçairo              | nɨˈsajɾu        | nez̻ajɾu        | 3
-    # nuobo                | ˈnwoβʊ          | nwoβu           | 2
-    # nó                   | ˈnɔ             | nɔ              | 1
-    # onte                 | ˈõtɨ            | õŋte            | 3
-    # oucidental           | ows̻idẽˈtal     | ows̻iðẽŋtal     | 2
-    # oufecialmente        | owfɨˌsjalˈmẽtɨ  | owfɨs̻jalmẽte   | 4
-    # ourdenhar            | ou̯ɾdɨˈɲaɾ      | owɾðẽŋaɾ        | 6
-    # oureginal            | owɾɨʒiˈnal      | owɾeɣĩŋal       | 5
-    # ourganizaçon         | ou̯rɡɐnizɐˈsõ   | owɾɣɐ̃ŋizɐsõŋ   | 8
-    # ouropeu              | owɾuˈpew        | owɾɔpew         | 2
-    # ourriêta             | ˈowrjetɐ        | owrjeta         | 2
-    # paxarina             | pɐʃɐˈɾinɐ       | paʃaɾĩŋa        | 6
-    # pequeinho            | pɨˈkɐiɲu        | pekɨĩŋu         | 5
-    # piranha              | piˈraɲɐ         | piɾɐ̃ŋa         | 5
-    # puis                 | ˈpujs̺          | pujs̺           | 1
-    # pul                  | ˈpul            | pul             | 1
-    # puorta               | ˈpwoɾtɐ         | pwoɾta          | 2
-    # purmeiro             | puɾˈmɐjɾu       | puɾmejɾu        | 2
-    # quaije               | ˈkwajʒɨ         | kwajʒe          | 2
-    # quando               | ˈkwɐ̃du         | kwɐ̃du          | 1
-    # quelobrinas          | kɨluˈbrinas̺    | kɨlɔbɾĩŋas̺     | 5
-    # quemun               | kɨˈmun          | kɨmũŋ           | 3
-    # rabielho             | rɐˈβjeʎu        | raβjeʎu         | 2
-    # rico                 | ˈriku           | riku            | 1
-    # salir                | s̺ɐˈliɾ         | s̺aliɾ          | 2
-    # screbir              | s̺krɨˈβiɾ       | s̺kɾeβiɾ        | 3
-    # segar                | s̺ɨˈɣaɾ         | s̺eɣaɾ          | 2
-    # sendo                | ˈsẽdu           | s̺ẽŋdu          | 3
-    # ser                  | ˈseɾ            | s̺eɾ            | 2
-    # sida                 | ˈsidɐ           | s̺iða           | 4
-    # sidas                | ˈsidɐs̺         | s̺iðas̺         | 4
-    # sido                 | ˈsidu           | s̺iðu           | 3
-    # sidos                | ˈsidus̺         | s̺iðɔs̺         | 4
-    # simple               | ˈs̺ĩplɨ         | s̺imple         | 4
-    # sobrino              | s̺uˈbɾinu       | s̺ɔbɾĩŋu        | 4
-    # sodes                | ˈsodɨs̺         | s̺ɔðes̺         | 5
-    # somos                | ˈsomus̺         | s̺ɔmus̺         | 3
-    # son                  | ˈsõ             | s̺õŋ            | 3
-    # sou                  | ˈsow            | s̺ow            | 2
-    # spanha               | ˈs̺pɐɲɐ         | s̺pɐ̃ŋa         | 4
-    # squierdo             | ˈs̺kjeɾdu       | s̺kjeɾðu        | 2
-    # sós                  | ˈs̺ɔs̺          | s̺ɔs̺           | 1
-    # talbeç               | talˈbes         | talbes          | 1
-    # tamien               | tɐˈmjẽ          | tɐ̃ŋjẽŋ         | 3
-    # tascar               | tɐs̺ˈkaɾ        | tas̺kaɾ         | 2
-    # tener                | tɨˈneɾ          | tẽŋeɾ           | 3
-    # trasdonte            | ˈtɾɐz̺dõtɨ      | tɾas̺dõŋte      | 5
-    # trasdontonte         | ˈtɾɐz̺dõtõtɨ    | tɾas̺dõŋtõŋte   | 6
-    # ye                   | ˈje             | je              | 1
-    # yê                   | ˈje             | jê              | 2
-    # zastre               | ˈzas̺tɾɨ        | zas̺tɾɨ         | 1
-    # zeigual              | zɐjˈɡwal        | zɐjɡwal         | 1
-    # zenhar               | zɨˈɲaɾ          | zẽŋaɾ           | 3
-    # áfrica               | ˈafɾikɐ         | ɐ̃fɾika         | 3
-    # çcansar              | skɐ̃ˈs̺aɾ       | skɐ̃ŋs̺aɾ       | 1
-    # çcrebir              | skɾɨˈβiɾ        | skɾeβiɾ         | 2
-    # çcriçon              | skɾiˈsõ         | skɾisõ          | 1
-    # çtinto               | ˈstĩtu          | z̻tĩŋtu         | 3
-    # érades               | ˈɛɾɐdɨs̺        | ɛɾaðes̺         | 4
-    # éramos               | ˈɛɾɐmus̺        | ɛɾɐ̃ŋɔs̺        | 4
-    # éran                 | ˈɛɾɐn           | ɛɾɐ̃ŋ           | 3
-    # ũ                    | ˈũ              | ũ               | 1
-    # ũa                   | ˈũŋɐ            | ũŋɐ             | 1
-    # ua                   | ˈũŋɐ            | wa              | 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "sklearn_crfsuite",
     "editdistance",
     "joblib",
-    "orthography2ipa>=0.3.0a1",
+    "orthography2ipa>=1.71.0a1",
 ]
 keywords = ["mirandese", "mwl", "phonemizer", "g2p", "ipa", "tts"]
 classifiers = [


### PR DESCRIPTION
## What

Migrates `OrthographyRulesMWL` (the last unmigrated Mirandese consumer) onto the shared **orthography2ipa** pronunciation lattice, matching the Barranquenho / arbtok / tugaphone pattern.

- Grapheme segmentation is now delegated to `orthography2ipa.phonetok.PhonetokTokenizer` (a maximal-munch trie over the Mirandese grapheme set in `g2p.json`). The bespoke `while i < len(word)` scanner and its manual index arithmetic are gone.
- Every context-sensitive realisation rule (b/d/g lenition, c/g softening, sibilant voicing, `i`/`u` glides, word-initial `l` palatalisation, `n`→[ŋ] before velars, final `-o` raising, the trill/tap `r` split, `qu`/`gu`, Sendinese `lh`→[l]) runs as a `LatticeRescorer` (B4 seam) over the shared per-grapheme `SegmentSlot` lattice.
- Re-pin `orthography2ipa>=1.71.0a1` for the phonetok/rescorer API.
- Architecture documented in README + `docs/api.md`.

## Accuracy

Output is **byte-for-byte identical** to the previous scanner across the full gold dictionary in all three dialects (Central / Raiano / Sendinese), verified against the pre-refactor implementation. The in-repo PER regression benchmark is therefore unchanged:

| backend | PER (old) | PER (new) |
|---|---|---|
| rules | 0.3586 | 0.3586 |

Full suite: `49 passed`.

## Notes for reviewers

- The `g2p.json` grapheme table still contains gold-fitted word-fragment "graphemes" (`era`, `muo`, `poss`, `fuor`, …). These are retained so segmentation stays identical; they are **not** real phonological rules and are flagged as a follow-up cleanup — not harvested upstream to the o2i `mwl` spec.
- No harvestable research-grounded rules were found: the rule set is eyeballed (several rule bodies explicitly note "beyond this rule-based phonemizer, defaulting to …") and `g2p.json` is heavily gold-fitted; the `rules` backend scores PER 0.3586, worse than the o2i `mwl` spec (~0.185), so there is nothing to contribute back.
- The realisation rules read char-level context (`word[i±1]`), a quirk of the original that peeks one char into a multigraph; the rescorer is bound to the source word to reproduce this faithfully. A future pass could reformulate them as pure grapheme-level `RescoreContext` rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)