### PR TITLE
fix(license): replace GPL python-Levenshtein with MIT rapidfuzz

### DIFF
--- a/mwl_phonemizer/crf_mwl.py
+++ b/mwl_phonemizer/crf_mwl.py
@@ -2,7 +2,7 @@ import random
 
 from mwl_phonemizer.base import MirandesePhonemizer, Dialects
 import sklearn_crfsuite
-import Levenshtein as lev
+from rapidfuzz.distance import Levenshtein
 from enum import Enum
 import joblib
 
@@ -21,7 +21,7 @@ def align_with_lev(espeak_seq: str, gold_seq: str):
     es = list(espeak_seq)
     gd = list(gold_seq)
 
-    ops = lev.editops(es, gd)
+    ops = [(e.tag, e.src_pos, e.dest_pos) for e in Levenshtein.editops(es, gd)]
     es_aligned, gd_aligned = [], []
     i, j = 0, 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "JarbasAi", email = "jarbasai@mailfence.com" }]
 requires-python = ">=3.9"
 dependencies = [
-    "python-Levenshtein",
+    "rapidfuzz",
     "sklearn_crfsuite",
     "editdistance",
     "joblib",


### PR DESCRIPTION
## Summary
- Swap `python-Levenshtein` (GPL-2.0-or-later, StrongCopyleft) for `rapidfuzz` (MIT) in `pyproject.toml`.
- `mwl_phonemizer/crf_mwl.py`: `import Levenshtein as lev` → `from rapidfuzz.distance import Levenshtein`; `lev.editops(es, gd)` → `[(e.tag, e.src_pos, e.dest_pos) for e in Levenshtein.editops(es, gd)]`, matching the `(op, src, tgt)` tuple shape the CRF alignment code already consumes.

## Verification
- Compared `python-Levenshtein.editops` vs `rapidfuzz.distance.Levenshtein.editops` (converted) on 7 word pairs including inserts/deletes/replaces/mixed-Unicode IPA strings — outputs identical in every case.
- `uv pip install -e .` resolves with rapidfuzz only; no GPL dependency pulled in.
- `pytest tests/ -q` → 49 passed (including CRF-adjacent regression/eval tests).
- Confirmed no remaining `python-Levenshtein`/`import Levenshtein` references in the repo.

## Test plan
- [x] CI green