### PR TITLE
refactor: stop subclassing G2PPlugin — it was never a plugin

### DIFF
--- a/mwl_phonemizer/__init__.py
+++ b/mwl_phonemizer/__init__.py
@@ -24,7 +24,7 @@ from functools import lru_cache
 from typing import List, Optional
 
 from orthography2ipa import G2P
-from orthography2ipa.g2p_plugin import G2PPlugin, WordContext
+from orthography2ipa import WordContext
 
 from mwl_phonemizer.crf import CRFCorrector, strip_stress
 from mwl_phonemizer.gold import GOLD, CENTRAL, SENDINESE, RAIANO
@@ -38,7 +38,7 @@ def strip_markers(ipa: str) -> str:
     return ipa.replace(".", "").replace("(", "").replace(")", "")
 
 
-class MirandesePhonemizer(G2PPlugin):
+class MirandesePhonemizer:
     """Mirandese G2P: gold-dictionary lookup, o2i lattice base, CRF correction.
 
     :param dialect: ``orthography2ipa`` spec code — one of :data:`DIALECTS`.
@@ -107,7 +107,8 @@ class MirandesePhonemizer(G2PPlugin):
         return self.g2p.transcribe_word(word)
 
     # ------------------------------------------------------------------
-    # orthography2ipa G2PPlugin interface
+    # The surface downstream code relies on. mwl_phonemizer is an engine built
+    # ON orthography2ipa, not a plugin to it — nothing there discovers or calls it.
     # ------------------------------------------------------------------
 
     @property

--- a/tests/test_phonemizer.py
+++ b/tests/test_phonemizer.py
@@ -1,7 +1,6 @@
 """Tests for the public MirandesePhonemizer API."""
 import pytest
 
-from orthography2ipa.g2p_plugin import G2PPlugin
 
 from mwl_phonemizer import (DIALECTS, MirandesePhonemizer, phonemize,
                             strip_markers, strip_stress)
@@ -68,8 +67,11 @@ def test_no_crf_falls_back_to_o2i_base():
     assert base.phonemize_word("fui", lookup=False) == "ˈfuj"
 
 
-def test_g2p_plugin_interface(pho):
-    assert isinstance(pho, G2PPlugin)
+def test_g2p_engine_surface(pho):
+    # An engine built ON orthography2ipa, not a plugin TO it — nothing there
+    # discovers or calls this. The surface is what matters, not inheritance.
+    for method in ("transcribe", "transcribe_word"):
+        assert callable(getattr(pho, method))
     assert pho.language_codes == ["mwl"]
     word = "lhéngua"
     assert pho.transcribe(word) == pho.phonemize(word)


### PR DESCRIPTION
Pairs with **orthography2ipa#369**, which removes the base class.

## Why

orthography2ipa **never discovered or called a `G2PPlugin`**. This package is an engine built **on** that library, not a plugin **to** it — the opposite direction. The base class asserted a relationship that did not exist, and naming both directions "plugin" is what made the extension system impossible to reason about.

What *is* a plugin there is a **step** — a syllabifier, a rescorer — discovered through an entry point and bound by a contract.

## What changes

Nothing about the engine: same methods, same behaviour, same public class name. Only the inherited-from-nothing base goes. `WordContext` now comes from the package root, where it has always been re-exported.

Tests assert the **surface** (`transcribe`, `transcribe_word`) rather than the inheritance, which is what downstream code actually relies on.