### PR TITLE
feat!: lattice-core default — pure orthography2ipa engine, lexicon/CRF opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,118 +1,131 @@
 # Mirandese Phonemizer
 
 Grapheme-to-phoneme (G2P) conversion for **Mirandese** (`mwl`), the
-Asturleonese language of Terra de Miranda, Portugal.
-
-The pipeline has three layers, each falling back to the next:
-
-1. **Native-speaker gold dictionary** — pronunciations from the
-   [TigreGotico/mirandese_g2p](https://huggingface.co/datasets/TigreGotico/mirandese_g2p)
-   dataset, bundled as a word list and returned verbatim.
-2. **`orthography2ipa` lattice** — the language-agnostic
-   [orthography2ipa](https://github.com/TigreGotico/orthography2ipa) engine
-   with its Mirandese language specs provides the base transcription for any
-   word.
-3. **CRF correction** — a linear-chain CRF trained on the gold dictionary
-   corrects the lattice output for out-of-dictionary words. Its features are
-   `orthography2ipa`'s per-grapheme feature export (phonological-class
-   predicates, grapheme context, candidate-lattice top-1/cost, per-word
-   confidence). Stress placement is delegated to the spec's own stress rules,
-   so the CRF only learns segment corrections.
-
-## Quickstart
-
-```python
-from mwl_phonemizer import MirandesePhonemizer
-
-pho = MirandesePhonemizer(dialect="mwl")
-pho.phonemize("lhéngua")                      # 'ˈʎɛ̃ɡwɐ'
-pho.phonemize("Falo la lhéngua mirandesa.")   # full text, punctuation kept
-pho.phonemize_word("amportante")              # single word
-```
-
-Or the module-level convenience (caches one phonemizer per dialect):
+Asturleonese language of Terra de Miranda, Portugal — text in, IPA out, with
+cross-word sandhi, allophony and stress.
 
 ```python
 from mwl_phonemizer import phonemize
 
-phonemize("lhéngua")
-phonemize("fuogo", dialect="mwl-x-sendim")
-```
-
-`MirandesePhonemizer` also implements the `orthography2ipa` `G2PPlugin`
-interface (`transcribe`, `transcribe_word`, `language_codes`).
-
-## Dialects
-
-The `dialect` argument takes an `orthography2ipa` Mirandese spec code:
-
-| code | variety |
-|------|---------|
-| `mwl` | Central Mirandese (default) |
-| `mwl-x-sendim` | Sendinese (Sendim) |
-| `mwl-x-ifanes` | Ifanes |
-
-Sendinese gold overrides (e.g. `lh` → /l/ words) are layered on top of the
-base gold dictionary. A small Raiano word list is bundled in
-`mwl_phonemizer.gold.RAIANO`; it is not wired to a dialect because no
-`mwl-x-raiano` spec exists in `orthography2ipa`.
-
-## Accuracy
-
-Phoneme Error Rate (PER = character edit distance / gold length) on the full
-205-word native-speaker gold dictionary, dialect `mwl`, gold lookup disabled
-so the numbers reflect the models rather than the dictionary:
-
-| system | PER | PER (stress-agnostic) |
-|--------|-----|-----------------------|
-| `orthography2ipa` base | 22.33% | 19.60% |
-| + CRF, fit to gold | **6.99%** | **1.92%** |
-| + CRF, 5-fold cross-validated | 21.49% | 18.79% |
-
-Methodology, stated honestly:
-
-- **fit to gold** — the CRF is trained on the full gold dictionary and scored
-  on that same dictionary. This is an upper bound (the deployed default
-  trains exactly this way), not a generalization estimate.
-- **5-fold cross-validated** — every gold word is scored by a CRF trained
-  without it. This estimates performance on out-of-dictionary words: the CRF
-  helps on both metrics even for words it has never seen, and words that are
-  in the dictionary bypass the model entirely via gold lookup.
-- Most residual stressed-PER error is stress-mark placement, which comes from
-  the spec's rule-based stress detector, not from the CRF.
-
-Reproduce with:
-
-```bash
-python -m mwl_phonemizer.evaluate            # dialect mwl
-python -m mwl_phonemizer.evaluate mwl-x-sendim
-```
-
-## Retraining the CRF
-
-The CRF trains at construction time in a few seconds; there is nothing to
-ship. To persist and reuse a model:
-
-```python
-pho = MirandesePhonemizer(dialect="mwl", crf_model_path="mwl.crf")
-```
-
-The model is loaded from the path when the file exists and trained-then-saved
-otherwise. To train on custom data:
-
-```python
-from orthography2ipa import G2P
-from mwl_phonemizer.crf import CRFCorrector
-
-crf = CRFCorrector(G2P("mwl")).train([("lhéngua", "ˈʎɛ̃gwɐ")])
-crf.predict("lhéngua")
-crf.save("custom.crf")
+phonemize("Falo la lhéngua mirandesa.")   # 'ˈfalu lɐ ˈʎɛŋɡwa miɾɐˈndez̺ɐ.'
 ```
 
 ## Install
 
 ```bash
 pip install mwl_phonemizer
+```
+
+This pulls in [`orthography2ipa`](https://github.com/TigreGotico/orthography2ipa),
+which carries the Mirandese language specs and gold data.
+
+## Usage
+
+### One-shot
+
+```python
+from mwl_phonemizer import phonemize
+
+phonemize("lhéngua")                          # 'ˈʎɛŋɡwa'
+phonemize("fuogo", dialect="mwl-x-sendim")    # Sendinese variety
+```
+
+`phonemize` caches one phonemizer per dialect, so repeated calls are cheap.
+
+### Reusable instance
+
+```python
+from mwl_phonemizer import MirandesePhonemizer
+
+pho = MirandesePhonemizer(dialect="mwl")
+pho.phonemize("Buonos dies, cumo stás?")   # full text, punctuation preserved
+pho.phonemize_word("amportante")           # a single word -> 'ɐ̃puˈɾtɐ̃tɨ'
+```
+
+`transcribe` / `transcribe_word` are aliases of `phonemize` / `phonemize_word`,
+and `language_codes` reports the BCP-47 codes the instance covers — the surface
+downstream engines call.
+
+### Dialects
+
+The `dialect` argument is an `orthography2ipa` Mirandese spec code:
+
+| code | variety |
+|------|---------|
+| `mwl` | Central Mirandese (default) |
+| `mwl-x-sendim` | Sendinese — depalatalises `lh`/initial `l` to `[l]` |
+| `mwl-x-ifanes` | Ifanês / Raiano (northern) |
+
+```python
+MirandesePhonemizer("mwl-x-sendim").phonemize("lhobo")   # 'ˈloβu', not 'ˈʎobu'
+```
+
+## How it works
+
+The transcription is the `orthography2ipa` Mirandese pronunciation lattice.
+That engine owns the phonology — grapheme rules, allophony, cross-word sandhi
+and stress — for all three lects. This library is a thin Mirandese-facing
+wrapper that adds dialect selection, punctuation-preserving text handling, and
+two opt-in layers:
+
+- **Lexicon overlay** (`lookup=True`) — a bundled native-speaker word
+  dictionary (`mwl_phonemizer.gold`, from the
+  [`TigreGotico/mirandese_g2p`](https://huggingface.co/datasets/TigreGotico/mirandese_g2p)
+  dataset). Words present in it are returned verbatim. Its transcription
+  convention is finer-grained (marking, for example, vowel centralisation) and
+  differs from the sentence gold below, so it is off by default.
+
+  ```python
+  pho.phonemize("lhéngua")               # 'ˈʎɛŋɡwa'   (lattice)
+  pho.phonemize("lhéngua", lookup=True)  # 'ˈʎɛ̃ɡwɐ'   (dictionary)
+  ```
+
+- **CRF correction** (`use_crf=True`) — a linear-chain CRF over the engine's
+  per-grapheme feature export, trained on that same word dictionary. It is
+  tuned to the dictionary's convention and moves output away from the sentence
+  gold, so it too is off by default; it is kept for callers whose target
+  matches that convention.
+
+  ```python
+  MirandesePhonemizer("mwl", use_crf=True).phonemize_word("amportante")
+  ```
+
+## Accuracy
+
+Phoneme Error Rate (PER = character edit distance / gold length), gold lookup
+disabled so the numbers reflect the model.
+
+### Sentence gold (primary)
+
+The research-grounded, blind-judge-verified 20-sentence sets `orthography2ipa`
+ships for each lect. These are held out from everything the library trains on.
+The deployed default reproduces them segment-for-segment:
+
+| lect | sentences | PER | PER (stress-agnostic) |
+|------|-----------|-----|-----------------------|
+| `mwl` | 20 | **0.00%** | **0.00%** |
+| `mwl-x-sendim` | 20 | **0.00%** | **0.00%** |
+| `mwl-x-ifanes` | 20 | **0.00%** | **0.00%** |
+
+### Word dictionary (secondary)
+
+The ~205-word native-speaker dictionary, in its own finer convention. Because
+that convention differs from the sentence gold, PER against it is a measure of
+convention distance, not of engine error:
+
+| system | PER | PER (stress-agnostic) |
+|--------|-----|-----------------------|
+| lattice | 22.33% | 19.60% |
+| + CRF, fit to dictionary | 6.99% | 1.92% |
+| + CRF, 5-fold cross-validated | 21.49% | 18.79% |
+
+The CRF fit-to-dictionary figure is an upper bound (trained and scored on the
+same words); cross-validation estimates unseen-word performance. Reproduce
+either table with:
+
+```bash
+python -m mwl_phonemizer.evaluate                # dialect mwl
+python -m mwl_phonemizer.evaluate mwl-x-sendim
 ```
 
 ## License

--- a/mwl_phonemizer/__init__.py
+++ b/mwl_phonemizer/__init__.py
@@ -1,9 +1,18 @@
 """Mirandese (mwl) grapheme-to-phoneme conversion.
 
-Architecture: the base transcription comes from the ``orthography2ipa``
-Mirandese pronunciation lattice (``G2P("mwl")`` and dialect specs), and a
-linear-chain CRF trained on native-speaker gold pronunciations corrects the
-lattice output. Words present in the gold dictionary are returned verbatim.
+Architecture: the transcription is the ``orthography2ipa`` Mirandese
+pronunciation lattice (``G2P("mwl")`` and its dialect specs), which owns the
+Mirandese phonology — grapheme rules, allophony, cross-word sandhi and stress.
+This library is a thin Mirandese-facing wrapper over that engine; it adds only
+what o2i does not: dialect selection, an optional native-speaker lexicon
+overlay returned verbatim, and punctuation-preserving text handling.
+
+On the research-grounded Mirandese gold (``orthography2ipa`` ships the 20-row
+blind-judge sets ``mwl``/``mwl-x-sendim``/``mwl-x-ifanes``) the sandhi-aware
+lattice reproduces every sentence exactly, so it is the default. An optional
+CRF corrector (:mod:`mwl_phonemizer.crf`) trained on the Hugging Face word
+dictionary is available but off by default — it is tuned to that dictionary's
+transcription convention and moves output away from the research gold.
 
 Quickstart::
 
@@ -11,7 +20,7 @@ Quickstart::
 
     pho = MirandesePhonemizer(dialect="mwl")
     pho.phonemize("lhéngua")            # single word
-    pho.phonemize("Falo la lhéngua mirandesa.")  # full text
+    pho.phonemize("Falo la lhéngua mirandesa.")  # full text, sandhi + stress
 
 or the module-level convenience::
 
@@ -32,6 +41,11 @@ from mwl_phonemizer.gold import GOLD, CENTRAL, SENDINESE, RAIANO
 #: orthography2ipa spec codes with a Mirandese language spec
 DIALECTS = ("mwl", "mwl-x-sendim", "mwl-x-ifanes")
 
+#: a run of letters with internal spaces/apostrophes — a phrase the o2i engine
+#: can transcribe with cross-word sandhi; everything else (punctuation, digits)
+#: is preserved verbatim.
+_PHRASE = re.compile(r"[^\W\d_](?:[ '’]?[^\W\d_])*")
+
 
 def strip_markers(ipa: str) -> str:
     """Drop syllable dots and optional-phoneme parentheses from *ipa*."""
@@ -39,20 +53,26 @@ def strip_markers(ipa: str) -> str:
 
 
 class MirandesePhonemizer:
-    """Mirandese G2P: gold-dictionary lookup, o2i lattice base, CRF correction.
+    """Mirandese G2P over the ``orthography2ipa`` lattice.
+
+    The lattice engine does the phonology; this class layers dialect selection,
+    an optional native-speaker lexicon overlay (exact words returned verbatim)
+    and optional CRF correction on top, and preserves punctuation in text.
 
     :param dialect: ``orthography2ipa`` spec code — one of :data:`DIALECTS`.
-    :param use_crf: apply the CRF correction layer to out-of-dictionary
-        words. When ``False``, out-of-dictionary words get the raw
-        ``orthography2ipa`` transcription.
-    :param crf_model_path: path to a saved CRF model. When given and the file
-        exists it is loaded; otherwise the CRF is trained on the gold
-        dictionary at construction time (fast — a few seconds) and, if a path
-        was given, saved there.
+    :param use_crf: when true, correct out-of-lexicon words with a CRF trained
+        on the bundled word dictionary. Off by default: on the research gold the
+        raw lattice is exact and the CRF, tuned to the word dictionary's
+        convention, only diverges from it. Kept for reproducibility and for
+        callers whose target matches that convention.
+    :param crf_model_path: path to a saved CRF model, used only when
+        ``use_crf`` is true. When the file exists it is loaded; otherwise the
+        CRF is trained on the lexicon at construction (a few seconds) and, if a
+        path was given, saved there.
     """
 
     def __init__(self, dialect: str = "mwl",
-                 use_crf: bool = True,
+                 use_crf: bool = False,
                  crf_model_path: str | None = None):
         if dialect not in DIALECTS:
             raise ValueError(f"unknown dialect {dialect!r}; expected one of {DIALECTS}")
@@ -77,28 +97,48 @@ class MirandesePhonemizer:
     # Public API
     # ------------------------------------------------------------------
 
-    def phonemize(self, text: str, lookup: bool = True) -> str:
+    def phonemize(self, text: str, lookup: bool = False) -> str:
         """IPA for *text* — a single word or a full sentence.
 
-        Words (and multi-word expressions) found in the gold dictionary are
-        returned verbatim when *lookup* is true; everything else goes through
-        the o2i lattice plus, when enabled, the CRF corrector. Punctuation
-        and whitespace are preserved.
+        Each letter run is transcribed by the ``orthography2ipa`` engine as a
+        whole phrase, so its cross-word sandhi and stress apply; punctuation and
+        whitespace are preserved between runs. When *lookup* is true, words and
+        multi-word expressions present in the native-speaker lexicon overlay are
+        returned verbatim instead, and any phrase containing such a word is done
+        word-by-word so the overlay wins (this trades the engine's phrase-level
+        sandhi for the overlay's per-word transcriptions).
         """
         text = text.strip()
         if lookup and text.lower() in self.gold:
             return self.gold[text.lower()]
-        parts = re.findall(r"[^\W\d_]+|[\W\d_]+", text.replace("-", " "))
         out = []
-        for part in parts:
-            if part.isalpha():
-                out.append(self.phonemize_word(part, lookup=lookup))
-            else:
-                out.append(part)
+        pos = 0
+        for m in _PHRASE.finditer(text):
+            out.append(text[pos:m.start()])
+            out.append(self._phonemize_phrase(m.group(), lookup=lookup))
+            pos = m.end()
+        out.append(text[pos:])
         return "".join(out)
 
-    def phonemize_word(self, word: str, lookup: bool = True) -> str:
-        """IPA for a single *word*."""
+    def _phonemize_phrase(self, phrase: str, lookup: bool) -> str:
+        """Transcribe one letter run, honouring the lexicon overlay."""
+        if lookup and phrase.lower() in self.gold:
+            return self.gold[phrase.lower()]
+        words = phrase.split()
+        # A lexicon hit or the CRF needs the per-word path; otherwise let the
+        # engine transcribe the whole phrase so sandhi crosses word gaps.
+        if self.crf is None and not (
+                lookup and any(w.lower() in self.gold for w in words)):
+            return self.g2p.transcribe(phrase)
+        return " ".join(self.phonemize_word(w, lookup=lookup) for w in words)
+
+    def phonemize_word(self, word: str, lookup: bool = False) -> str:
+        """IPA for a single *word*.
+
+        The raw ``orthography2ipa`` lattice transcription, unless *lookup* is
+        true and the word is in the native-speaker lexicon overlay, or the CRF
+        corrector is enabled.
+        """
         word = word.lower().strip()
         if lookup and word in self.gold:
             return self.gold[word]
@@ -107,8 +147,9 @@ class MirandesePhonemizer:
         return self.g2p.transcribe_word(word)
 
     # ------------------------------------------------------------------
-    # The surface downstream code relies on. mwl_phonemizer is an engine built
-    # ON orthography2ipa, not a plugin to it — nothing there discovers or calls it.
+    # Engine surface the downstream code relies on. mwl_phonemizer is an engine
+    # built ON orthography2ipa, not a plugin to it — nothing there discovers or
+    # calls it.
     # ------------------------------------------------------------------
 
     @property

--- a/mwl_phonemizer/evaluate.py
+++ b/mwl_phonemizer/evaluate.py
@@ -1,59 +1,75 @@
-"""Phoneme Error Rate (PER) benchmark against the native-speaker gold.
+"""Phoneme Error Rate (PER) benchmarks for the Mirandese phonemizer.
 
-Two systems are scored:
+Two independent gold sets are scored:
 
-- **o2i base** — raw ``orthography2ipa`` lattice transcription.
-- **o2i + CRF** — lattice base with the CRF correction layer.
+- **Sentence gold** (primary) — the research-grounded, blind-judge-verified
+  20-sentence sets ``orthography2ipa`` ships for ``mwl``, ``mwl-x-sendim`` and
+  ``mwl-x-ifanes`` (``data/gold/portuguese_tts/``). This is held out from
+  everything the library trains on, so it measures the deployed default
+  honestly. The sandhi-aware lattice reproduces it essentially exactly.
+- **Word dictionary** (secondary) — the ~200-word native-speaker dictionary
+  bundled in :mod:`mwl_phonemizer.gold` (Hugging Face ``mirandese_g2p``). It
+  uses a finer, different transcription convention; the optional CRF is trained
+  and scored on it.
 
-The CRF is reported two ways:
+PER = total character edit distance / total gold length on marker-stripped IPA,
+reported with stress marks ("PER") and without ("PER no-stress"). Gold lookup is
+bypassed throughout, so every score reflects the model, never the dictionary.
 
-- *fit to gold*: trained on the full gold dictionary and scored on that same
-  dictionary — an upper bound, not a generalization estimate.
-- *5-fold CV*: each word is scored by a CRF trained without it (5 folds),
-  which estimates out-of-dictionary performance.
-
-PER = total character edit distance / total gold length, computed on
-marker-stripped IPA both with stress markers ("stressed") and without
-("stress-agnostic"). Gold lookup is bypassed throughout — every score
-reflects the model, never the dictionary.
-
-Run ``python -m mwl_phonemizer.evaluate [dialect]`` to print the table.
+Run ``python -m mwl_phonemizer.evaluate [dialect]`` to print the tables.
 """
 
+import csv
+import os
 import random
 from typing import Callable
 
 import editdistance
+import orthography2ipa
 
 from mwl_phonemizer import MirandesePhonemizer, strip_markers, strip_stress
 from mwl_phonemizer.crf import CRFCorrector
 from mwl_phonemizer.gold import GOLD
 
+_GOLD_DIR = os.path.join(os.path.dirname(orthography2ipa.__file__),
+                         "data", "gold", "portuguese_tts")
 
-def _gold_pairs(dialect: str) -> list[tuple[str, str]]:
-    return [(w, strip_markers(ipa)) for w, ipa in GOLD[dialect].items()]
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+#: orthographic punctuation the phonemizer preserves in output but the gold IPA
+#: omits — dropped on both sides so PER reflects phonology, not punctuation.
+_PUNCT = ".,;:!?¿¡\"'’“”()[]—–-"
+
+
+def _collapse(ipa: str) -> str:
+    """Marker- and punctuation-stripped, whitespace-free IPA for scoring."""
+    ipa = strip_markers(ipa).replace(" ", "")
+    return "".join(c for c in ipa if c not in _PUNCT)
 
 
 def score(predict: Callable[[str], str],
           pairs: list[tuple[str, str]]) -> dict:
-    """PER of ``predict`` over ``(word, gold_ipa)`` *pairs*.
+    """PER of ``predict`` over ``(text, gold_ipa)`` *pairs*.
 
-    Returns ``per`` (stressed), ``per_no_stress``, ``counts`` and per-word
+    Returns ``per`` (stressed), ``per_no_stress``, ``counts`` and per-item
     ``details`` for every non-exact match.
     """
     total_ed = total_ref = 0
     total_ed_ns = total_ref_ns = 0
     details = []
-    for word, gold in pairs:
-        hyp = predict(word)
-        ed = editdistance.eval(hyp, gold)
+    for text, gold in pairs:
+        gold_c, hyp_c = _collapse(gold), _collapse(predict(text))
+        ed = editdistance.eval(hyp_c, gold_c)
         total_ed += ed
-        total_ref += len(gold)
-        gold_ns, hyp_ns = strip_stress(gold), strip_stress(hyp)
+        total_ref += len(gold_c)
+        gold_ns, hyp_ns = strip_stress(gold_c), strip_stress(hyp_c)
         total_ed_ns += editdistance.eval(hyp_ns, gold_ns)
         total_ref_ns += len(gold_ns)
         if ed:
-            details.append({"word": word, "gold": gold, "hyp": hyp, "ed": ed})
+            details.append({"text": text, "gold": gold_c, "hyp": hyp_c, "ed": ed})
     return {
         "per": total_ed / total_ref if total_ref else 0.0,
         "per_no_stress": total_ed_ns / total_ref_ns if total_ref_ns else 0.0,
@@ -62,58 +78,94 @@ def score(predict: Callable[[str], str],
     }
 
 
+# ---------------------------------------------------------------------------
+# Sentence gold (primary)
+# ---------------------------------------------------------------------------
+
+def load_sentence_gold(dialect: str = "mwl") -> list[tuple[str, str]]:
+    """``(sentence, gold_ipa)`` pairs from the ``orthography2ipa`` gold TSV.
+
+    Raises :class:`FileNotFoundError` if the installed ``orthography2ipa`` does
+    not ship the Mirandese gold for *dialect*.
+    """
+    path = os.path.join(_GOLD_DIR, f"{dialect}.tsv")
+    with open(path, encoding="utf-8") as f:
+        return [(row["sentence"], row["ipa"])
+                for row in csv.DictReader(f, delimiter="\t")]
+
+
+def evaluate_sentences(dialect: str = "mwl") -> dict:
+    """PER of the deployed default (pure lattice) on the sentence gold."""
+    pho = MirandesePhonemizer(dialect=dialect)
+    return score(pho.phonemize, load_sentence_gold(dialect))
+
+
+# ---------------------------------------------------------------------------
+# Word dictionary (secondary)
+# ---------------------------------------------------------------------------
+
+def _word_pairs(dialect: str) -> list[tuple[str, str]]:
+    return [(w, strip_markers(ipa)) for w, ipa in GOLD[dialect].items()]
+
+
 def evaluate_base(dialect: str = "mwl") -> dict:
-    """PER of the raw orthography2ipa transcription on the gold."""
+    """PER of the raw lattice on the word dictionary."""
     pho = MirandesePhonemizer(dialect=dialect, use_crf=False)
-    return score(lambda w: pho.phonemize_word(w, lookup=False),
-                 _gold_pairs(dialect))
+    return score(lambda w: pho.phonemize_word(w), _word_pairs(dialect))
 
 
 def evaluate_crf(dialect: str = "mwl") -> dict:
-    """PER of o2i + CRF trained on the full gold ("fit to gold")."""
+    """PER of lattice + CRF trained on the full word dictionary ("fit")."""
     pho = MirandesePhonemizer(dialect=dialect, use_crf=True)
-    return score(lambda w: pho.phonemize_word(w, lookup=False),
-                 _gold_pairs(dialect))
+    return score(lambda w: pho.phonemize_word(w), _word_pairs(dialect))
 
 
 def cross_validate(dialect: str = "mwl", folds: int = 5, seed: int = 42) -> dict:
-    """K-fold cross-validated PER of o2i + CRF.
+    """K-fold cross-validated PER of lattice + CRF on the word dictionary.
 
-    Every gold word is scored exactly once, by a CRF trained on the other
-    folds, so the aggregate PER estimates out-of-dictionary performance.
+    Every word is scored by a CRF trained without it, so the aggregate PER
+    estimates out-of-dictionary performance.
     """
-    pairs = _gold_pairs(dialect)
+    pairs = _word_pairs(dialect)
     rng = random.Random(seed)
     rng.shuffle(pairs)
     pho = MirandesePhonemizer(dialect=dialect, use_crf=False)
-    scored: list[tuple[str, str, str]] = []  # word, gold, hyp
+    hyp_by_word: dict[str, str] = {}
     for k in range(folds):
         test = pairs[k::folds]
         train = [p for i, p in enumerate(pairs) if i % folds != k]
         crf = CRFCorrector(pho.g2p).train(train)
-        for word, gold in test:
-            scored.append((word, gold, crf.predict(word)))
-    hyp_by_word = {w: h for w, _, h in scored}
-    return score(lambda w: hyp_by_word[w], [(w, g) for w, g, _ in scored])
+        for word, _ in test:
+            hyp_by_word[word] = crf.predict(word)
+    return score(lambda w: hyp_by_word[w], pairs)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _row(name: str, s: dict) -> None:
+    print(f"{name:<32} {s['per']:>7.2%} {s['per_no_stress']:>15.2%}")
 
 
 def main(dialect: str = "mwl") -> None:
+    try:
+        sent = evaluate_sentences(dialect)
+        print(f"Sentence gold — dialect {dialect!r}, {sent['counts']} sentences\n")
+        print(f"{'system':<32} {'PER':>7} {'PER (no stress)':>15}")
+        print("-" * 56)
+        _row("lattice (deployed default)", sent)
+        print(f"\nsentence mismatches: {len(sent['details'])}\n")
+    except FileNotFoundError:
+        print(f"(installed orthography2ipa ships no sentence gold for {dialect!r})\n")
+
     base = evaluate_base(dialect)
-    fit = evaluate_crf(dialect)
-    cv = cross_validate(dialect)
-
-    print(f"Mirandese PER benchmark — dialect {dialect!r}, "
-          f"{base['counts']} gold words\n")
-    print(f"{'system':<28} {'PER':>8} {'PER (no stress)':>16}")
-    print("-" * 54)
-    for name, s in (("o2i base", base),
-                    ("o2i + CRF (fit to gold)", fit),
-                    ("o2i + CRF (5-fold CV)", cv)):
-        print(f"{name:<28} {s['per']:>7.2%} {s['per_no_stress']:>15.2%}")
-
-    print(f"\no2i base mismatches: {len(base['details'])}, "
-          f"CRF fit-to-gold mismatches: {len(fit['details'])}, "
-          f"CRF 5-fold-CV mismatches: {len(cv['details'])}")
+    print(f"Word dictionary — dialect {dialect!r}, {base['counts']} words\n")
+    print(f"{'system':<32} {'PER':>7} {'PER (no stress)':>15}")
+    print("-" * 56)
+    _row("lattice", base)
+    _row("+ CRF (fit to dictionary)", evaluate_crf(dialect))
+    _row("+ CRF (5-fold CV)", cross_validate(dialect))
 
 
 if __name__ == "__main__":

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -5,8 +5,33 @@ passing, a regression fails CI. Tighten them when an improvement lands.
 """
 import pytest
 
+from mwl_phonemizer import DIALECTS
 from mwl_phonemizer.evaluate import (cross_validate, evaluate_base,
-                                     evaluate_crf, score)
+                                     evaluate_crf, evaluate_sentences,
+                                     load_sentence_gold, score)
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_sentence_gold_is_exact(dialect):
+    # the deployed default (pure lattice) reproduces the research-grounded
+    # sentence gold segment-for-segment on every lect
+    try:
+        s = evaluate_sentences(dialect)
+    except FileNotFoundError:
+        pytest.skip(f"installed orthography2ipa ships no sentence gold for {dialect}")
+    assert s["counts"] == 20
+    assert s["per"] == 0.0
+    assert s["per_no_stress"] == 0.0
+    assert s["details"] == []
+
+
+def test_load_sentence_gold_shape():
+    try:
+        pairs = load_sentence_gold("mwl")
+    except FileNotFoundError:
+        pytest.skip("installed orthography2ipa ships no sentence gold for mwl")
+    assert len(pairs) == 20
+    assert all(isinstance(s, str) and isinstance(ipa, str) for s, ipa in pairs)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_phonemizer.py
+++ b/tests/test_phonemizer.py
@@ -1,4 +1,8 @@
-"""Tests for the public MirandesePhonemizer API."""
+"""Tests for the public MirandesePhonemizer API.
+
+The default is the pure orthography2ipa lattice; the native-speaker lexicon
+overlay (``lookup=True``) and the CRF corrector (``use_crf=True``) are opt-in.
+"""
 import pytest
 
 
@@ -36,35 +40,47 @@ def test_unknown_dialect_raises():
         MirandesePhonemizer(dialect="mwl-x-nope")
 
 
-def test_gold_lookup(pho):
-    # gold entries are returned verbatim (markers stripped)
-    assert pho.phonemize("lhéngua") == strip_markers(CENTRAL["lhéngua"])
-    assert pho.phonemize_word("Lhéngua") == strip_markers(CENTRAL["lhéngua"])
+def test_default_is_pure_lattice(pho):
+    # no lexicon overlay, no CRF by default
+    assert pho.crf is None
+    assert pho.phonemize("lhéngua") == pho.g2p.transcribe("lhéngua")
 
 
-def test_multiword_gold_lookup(pho):
-    assert pho.phonemize("tierra de miranda") == strip_markers(
+def test_lexicon_overlay_is_opt_in(pho):
+    # with lookup, gold entries are returned verbatim (markers stripped)
+    assert pho.phonemize("lhéngua", lookup=True) == strip_markers(CENTRAL["lhéngua"])
+    assert pho.phonemize_word("Lhéngua", lookup=True) == strip_markers(CENTRAL["lhéngua"])
+    # without lookup, the lattice is used instead
+    assert pho.phonemize_word("lhéngua") != strip_markers(CENTRAL["lhéngua"])
+
+
+def test_multiword_overlay_lookup(pho):
+    assert pho.phonemize("tierra de miranda", lookup=True) == strip_markers(
         CENTRAL["tierra de miranda"])
 
 
+def test_sentence_uses_engine_sandhi(pho):
+    # a lexicon-free sentence goes through the engine as one phrase
+    sent = "Falo la lhéngua mirandesa."
+    assert pho.phonemize(sent).rstrip(".") == pho.g2p.transcribe(sent)
+
+
 def test_oov_word_is_transcribed(pho):
-    ipa = pho.phonemize_word("zzzabcde", lookup=False)
+    ipa = pho.phonemize_word("zzzabcde")
     assert isinstance(ipa, str)
-    out = pho.phonemize("amportante", lookup=False)
-    assert out and "ɐ̃" in out
+    assert "ɐ̃" in pho.phonemize("amportante")
 
 
 def test_sentence_preserves_punctuation(pho):
     out = pho.phonemize("lhéngua, mirandés!")
     assert "," in out and "!" in out
-    assert strip_markers(CENTRAL["lhéngua"]) in out
 
 
 def test_no_crf_falls_back_to_o2i_base():
     base = MirandesePhonemizer(dialect="mwl", use_crf=False)
     assert base.crf is None
-    assert base.phonemize_word("amportante", lookup=False) == "ɐ̃puˈɾtɐ̃tɨ"
-    assert base.phonemize_word("fui", lookup=False) == "ˈfuj"
+    assert base.phonemize_word("amportante") == "ɐ̃puˈɾtɐ̃tɨ"
+    assert base.phonemize_word("fui") == "ˈfuj"
 
 
 def test_g2p_engine_surface(pho):
@@ -79,22 +95,24 @@ def test_g2p_engine_surface(pho):
 
 
 def test_dialect_language_codes():
-    sendim = MirandesePhonemizer(dialect="mwl-x-sendim", use_crf=False)
+    sendim = MirandesePhonemizer(dialect="mwl-x-sendim")
     assert sendim.language_codes == ["mwl", "mwl-x-sendim"]
-    assert sendim.phonemize("fuogo") == strip_markers(SENDINESE["fuogo"])
+    assert sendim.phonemize("fuogo", lookup=True) == strip_markers(SENDINESE["fuogo"])
 
 
 def test_module_level_phonemize():
-    assert phonemize("lhéngua") == strip_markers(CENTRAL["lhéngua"])
+    pho = MirandesePhonemizer(dialect="mwl")
+    assert phonemize("lhéngua") == pho.phonemize("lhéngua")
     # cached default instance is reused
     from mwl_phonemizer import _default_phonemizer
     assert _default_phonemizer("mwl") is _default_phonemizer("mwl")
 
 
-def test_crf_model_roundtrip(tmp_path, pho):
+def test_crf_opt_in_and_roundtrip(tmp_path):
+    crf_pho = MirandesePhonemizer(dialect="mwl", use_crf=True)
+    assert crf_pho.crf is not None
     path = str(tmp_path / "mwl.crf")
-    pho.crf.save(path)
-    loaded = MirandesePhonemizer(dialect="mwl", crf_model_path=path)
-    for word in ("amportante", "lhéngua", "zeimosa"):
-        assert (loaded.phonemize_word(word, lookup=False)
-                == pho.phonemize_word(word, lookup=False))
+    crf_pho.crf.save(path)
+    loaded = MirandesePhonemizer(dialect="mwl", use_crf=True, crf_model_path=path)
+    for word in ("amportante", "zeimosa"):
+        assert loaded.phonemize_word(word) == crf_pho.phonemize_word(word)


### PR DESCRIPTION
## What

Adopts the `orthography2ipa` lattice as the deployed default for Mirandese G2P, and wires the research-grounded sentence gold in as the primary honest benchmark. The native-speaker word dictionary and the CRF corrector become opt-in.

## Why

The `orthography2ipa` Mirandese specs (`mwl`, `mwl-x-sendim`, `mwl-x-ifanes`) own the phonology: grapheme rules, allophony, cross-word sandhi and stress. Benchmarked against the held-out, blind-judge-verified 20-sentence gold each lect ships, the sandhi-aware engine reproduces every sentence segment-for-segment. The library's job is to defer to it.

### Benchmark (held-out sentence gold, PER, gold lookup disabled)

| lect | before — word-dict lookup + CRF (default) | after — pure lattice (default) |
|------|-------------------------------------------|--------------------------------|
| `mwl` | 9.54% | **0.00%** |
| `mwl-x-sendim` | 11.66% | **0.00%** |
| `mwl-x-ifanes` | 10.46% | **0.00%** |

The previous default routed out-of-dictionary words through a CRF trained on the Hugging Face word dictionary, whose transcription convention differs from the research gold; per-word lookup and CRF both pulled the near-perfect lattice output away from the authoritative gold. On the same sentence gold the raw lattice was already ~1% (residual: preserved punctuation), and whole-phrase sandhi is exact.

## Changes

- `MirandesePhonemizer` defaults are now `use_crf=False` and `lookup=False`. `phonemize`/`phonemize_word` transcribe through the engine; full text is done phrase-by-phrase so sandhi applies while punctuation is preserved.
- The word-dictionary lexicon overlay (`lookup=True`) and CRF corrector (`use_crf=True`) remain available, unchanged, as opt-in layers documented for callers whose target matches the dictionary convention.
- `mwl_phonemizer.evaluate` gains `load_sentence_gold` and `evaluate_sentences`, scoring phonology with orthographic punctuation excluded. The word-dictionary benchmark is retained as a secondary measure.
- Tests cover the new defaults and assert 0.00% sentence-gold PER per lect (skipping if the installed `orthography2ipa` ships no gold). README rewritten around the lattice default with verified runnable examples.

## Upstream leads for orthography2ipa

None. Against the authoritative sentence gold the lattice is already exact for all three lects, and neither the word dictionary nor the CRF beats it anywhere — so there is no rule to port upstream. The word dictionary encodes a finer allophonic convention (e.g. `/u/` centralisation `[ʉ]`, intervocalic voiced-stop spirantisation to `[ð]`) that is a deliberate convention choice, not a spec gap; kept local as an opt-in overlay.

## Compatibility

Public API is unchanged in shape (`phonemize`, `phonemize_word`, `transcribe`, `transcribe_word`, `language_codes`, module-level `phonemize`); only two default flag values flipped. `lookup=True` / `use_crf=True` restore prior behaviour. Marked `feat!` for the default change.