### PR TITLE
docs: human-gold accuracy, retire circular sentence-gold 0.00% claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,38 +95,63 @@ two opt-in layers:
 Phoneme Error Rate (PER = character edit distance / gold length), gold lookup
 disabled so the numbers reflect the model.
 
-### Sentence gold (primary)
+### Human gold — the only accuracy measurement (primary)
 
-The research-grounded, blind-judge-verified 20-sentence sets `orthography2ipa`
-ships for each lect. These are held out from everything the library trains on.
-The deployed default reproduces them segment-for-segment:
+The **only** human-authored Mirandese gold is the 219-word native-speaker
+dictionary [`TigreGotico/mirandese_g2p`](https://huggingface.co/datasets/TigreGotico/mirandese_g2p)
+(central 206, sendinese 11, raiano 2; rows routed to `mwl` / `mwl-x-sendim` /
+`mwl-x-ifanes` by their dialect tag). Everything below is scored against it,
+full dataset, no caps. Three normalisations are reported:
 
-| lect | sentences | PER | PER (stress-agnostic) |
-|------|-----------|-----|-----------------------|
-| `mwl` | 20 | **0.00%** | **0.00%** |
-| `mwl-x-sendim` | 20 | **0.00%** | **0.00%** |
-| `mwl-x-ifanes` | 20 | **0.00%** | **0.00%** |
+- **strict** — only structural markers (syllable dots, optional-phoneme
+  parentheses) removed; stress and every diacritic count.
+- **folded** — additionally folds three documented notation conventions:
+  stress marks (`ˈ ˌ`), length (`ː`), and tie-bars (`t͡ʃ`→`tʃ`).
+- **broad** — additionally folds the documented *broad-vs-narrow* gap: the
+  human gold is a **narrow** transcription, this engine is **broad-phonemic**.
+  Folds centralised `ʉ ʊ`→`u`, spirant `ð`→`d`, dark `ɫ`→`l`, lowered `e̞`→`e`,
+  and the apical/laminal sibilant diacritics (`s̺ s̻`→`s`). What remains is the
+  residual *true* phonemic error, not convention distance.
 
-### Word dictionary (secondary)
+| system | strict | folded | broad |
+|--------|-------:|-------:|------:|
+| **pure lattice** (deployed default) | 22.23% | 19.50% | **13.10%** |
+| + CRF, 5-fold cross-validated (honest OOD) | 21.18% | 18.16% | 12.73% |
+| + CRF, fit to dictionary (circular upper bound) | 8.79% | 3.83% | 2.59% |
+| lexicon lookup (`lookup=True`, memorisation) | 0.25% | 0.28% | 0.30% |
 
-The ~205-word native-speaker dictionary, in its own finer convention. Because
-that convention differs from the sentence gold, PER against it is a measure of
-convention distance, not of engine error:
+Reading the table honestly:
 
-| system | PER | PER (stress-agnostic) |
-|--------|-----|-----------------------|
-| lattice | 22.33% | 19.60% |
-| + CRF, fit to dictionary | 6.99% | 1.92% |
-| + CRF, 5-fold cross-validated | 21.49% | 18.79% |
+- **Lexicon lookup ≈ 0%** is pure memorisation — the lexicon *is* this gold, so
+  every word is returned verbatim. It is not an accuracy signal, and it mixes
+  the narrow lexicon convention into otherwise-broad sentences, which is why it
+  is off by default.
+- **CRF fit-to-dictionary (3.83% folded)** is trained and scored on the same
+  words — a circular upper bound, not accuracy.
+- **CRF 5-fold CV (18.16% folded)** is the honest out-of-dictionary estimate.
+  It edges the lattice by ~1.3pp folded, but on the convention-neutral **broad**
+  basis the gap collapses to 0.37pp (12.73% vs 13.10%): almost all of the CRF's
+  apparent gain is matching the lexicon's narrow convention, not fixing real
+  errors — and it couples every output to that convention. Hence the **pure
+  lattice remains the default**: convention-neutral, deterministic, untrained,
+  and statistically tied with the CRF on true phonemic error.
 
-The CRF fit-to-dictionary figure is an upper bound (trained and scored on the
-same words); cross-validation estimates unseen-word performance. Reproduce
-either table with:
+Reproduce with:
 
 ```bash
 python -m mwl_phonemizer.evaluate                # dialect mwl
 python -m mwl_phonemizer.evaluate mwl-x-sendim
 ```
+
+### Engine sentence set — a consistency check, NOT an accuracy claim
+
+`orthography2ipa` also ships 20-sentence sets per lect
+(`mwl`/`mwl-x-sendim`/`mwl-x-ifanes`). The lattice reproduces them at ~0% PER —
+but those sentences were **authored to match this engine's own output** (they
+are engine-pinned), so that 0% is an internal consistency check, **not** a
+measure of accuracy against human ground truth. Earlier versions of this README
+(and two downstream dataset cards) presented that 0% as the primary accuracy
+figure; that was circular. The human-gold table above is the real measurement.
 
 ## License
 

--- a/mwl_phonemizer/__init__.py
+++ b/mwl_phonemizer/__init__.py
@@ -7,12 +7,16 @@ This library is a thin Mirandese-facing wrapper over that engine; it adds only
 what o2i does not: dialect selection, an optional native-speaker lexicon
 overlay returned verbatim, and punctuation-preserving text handling.
 
-On the research-grounded Mirandese gold (``orthography2ipa`` ships the 20-row
-blind-judge sets ``mwl``/``mwl-x-sendim``/``mwl-x-ifanes``) the sandhi-aware
-lattice reproduces every sentence exactly, so it is the default. An optional
-CRF corrector (:mod:`mwl_phonemizer.crf`) trained on the Hugging Face word
-dictionary is available but off by default — it is tuned to that dictionary's
-transcription convention and moves output away from the research gold.
+Default rationale: against the only human-authored Mirandese gold — the 219-word
+``TigreGotico/mirandese_g2p`` dictionary — the pure lattice scores 19.50% PER
+(folded) / 13.10% once the documented broad-vs-narrow notation gap is folded out.
+An optional CRF corrector (:mod:`mwl_phonemizer.crf`) trained on that dictionary
+edges the lattice on folded PER, but on the convention-neutral basis the gap is
+~0.4pp: the CRF mostly matches the lexicon's narrow convention rather than fixing
+real errors, and couples every output to it. So the convention-neutral, untrained
+lattice is the default; the CRF and lexicon lookup are opt-in. (The o2i-shipped
+20-sentence sets, which the lattice reproduces at ~0% PER, are engine-pinned —
+a consistency check, not an accuracy measurement.) See the README accuracy table.
 
 Quickstart::
 

--- a/mwl_phonemizer/evaluate.py
+++ b/mwl_phonemizer/evaluate.py
@@ -1,16 +1,18 @@
 """Phoneme Error Rate (PER) benchmarks for the Mirandese phonemizer.
 
-Two independent gold sets are scored:
+Two gold sets are scored:
 
-- **Sentence gold** (primary) — the research-grounded, blind-judge-verified
-  20-sentence sets ``orthography2ipa`` ships for ``mwl``, ``mwl-x-sendim`` and
-  ``mwl-x-ifanes`` (``data/gold/portuguese_tts/``). This is held out from
-  everything the library trains on, so it measures the deployed default
-  honestly. The sandhi-aware lattice reproduces it essentially exactly.
-- **Word dictionary** (secondary) — the ~200-word native-speaker dictionary
-  bundled in :mod:`mwl_phonemizer.gold` (Hugging Face ``mirandese_g2p``). It
-  uses a finer, different transcription convention; the optional CRF is trained
-  and scored on it.
+- **Word dictionary** (primary — the only human accuracy measurement) — the
+  ~219-word native-speaker dictionary bundled in :mod:`mwl_phonemizer.gold`
+  (Hugging Face ``mirandese_g2p``), the only human-authored Mirandese gold. It
+  uses a finer *narrow* transcription convention; the optional CRF is trained
+  and scored on it (fit-to-dictionary is a circular upper bound, 5-fold CV the
+  honest out-of-dictionary estimate).
+- **Engine sentence set** (consistency check, NOT accuracy) — the 20-sentence
+  sets ``orthography2ipa`` ships for each lect (``data/gold/portuguese_tts/``).
+  The lattice reproduces them at ~0% PER, but they were authored to match this
+  engine's output (engine-pinned), so that 0% is an internal consistency check,
+  not a measure of accuracy against human ground truth.
 
 PER = total character edit distance / total gold length on marker-stripped IPA,
 reported with stress marks ("PER") and without ("PER no-stress"). Gold lookup is
@@ -79,7 +81,7 @@ def score(predict: Callable[[str], str],
 
 
 # ---------------------------------------------------------------------------
-# Sentence gold (primary)
+# Engine sentence set (consistency check, NOT accuracy)
 # ---------------------------------------------------------------------------
 
 def load_sentence_gold(dialect: str = "mwl") -> list[tuple[str, str]]:
@@ -95,13 +97,13 @@ def load_sentence_gold(dialect: str = "mwl") -> list[tuple[str, str]]:
 
 
 def evaluate_sentences(dialect: str = "mwl") -> dict:
-    """PER of the deployed default (pure lattice) on the sentence gold."""
+    """PER on the engine-pinned sentence set (consistency check, not accuracy)."""
     pho = MirandesePhonemizer(dialect=dialect)
     return score(pho.phonemize, load_sentence_gold(dialect))
 
 
 # ---------------------------------------------------------------------------
-# Word dictionary (secondary)
+# Word dictionary (primary — the only human accuracy measurement)
 # ---------------------------------------------------------------------------
 
 def _word_pairs(dialect: str) -> list[tuple[str, str]]:
@@ -149,23 +151,26 @@ def _row(name: str, s: dict) -> None:
 
 
 def main(dialect: str = "mwl") -> None:
-    try:
-        sent = evaluate_sentences(dialect)
-        print(f"Sentence gold — dialect {dialect!r}, {sent['counts']} sentences\n")
-        print(f"{'system':<32} {'PER':>7} {'PER (no stress)':>15}")
-        print("-" * 56)
-        _row("lattice (deployed default)", sent)
-        print(f"\nsentence mismatches: {len(sent['details'])}\n")
-    except FileNotFoundError:
-        print(f"(installed orthography2ipa ships no sentence gold for {dialect!r})\n")
-
+    # PRIMARY: the only human-authored gold.
     base = evaluate_base(dialect)
-    print(f"Word dictionary — dialect {dialect!r}, {base['counts']} words\n")
+    print(f"Human word gold (mirandese_g2p) — dialect {dialect!r}, "
+          f"{base['counts']} words — the only accuracy measurement\n")
     print(f"{'system':<32} {'PER':>7} {'PER (no stress)':>15}")
     print("-" * 56)
-    _row("lattice", base)
-    _row("+ CRF (fit to dictionary)", evaluate_crf(dialect))
-    _row("+ CRF (5-fold CV)", cross_validate(dialect))
+    _row("pure lattice (default)", base)
+    _row("+ CRF (5-fold CV, honest OOD)", cross_validate(dialect))
+    _row("+ CRF (fit to dict, circular)", evaluate_crf(dialect))
+
+    # Consistency check only — engine-pinned, NOT an accuracy claim.
+    try:
+        sent = evaluate_sentences(dialect)
+        print(f"\nEngine sentence set — {sent['counts']} sentences "
+              f"(engine-pinned consistency check, NOT accuracy)\n")
+        print(f"{'system':<32} {'PER':>7} {'PER (no stress)':>15}")
+        print("-" * 56)
+        _row("lattice", sent)
+    except FileNotFoundError:
+        print(f"\n(installed orthography2ipa ships no sentence set for {dialect!r})")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Recent Mirandese accuracy claims (README, `__init__`, and two downstream HF
dataset cards) rested on the `orthography2ipa`-shipped 20-sentence sets scoring
**0.00% PER**, presented as the *primary* gold. Those sentences were authored to
match this engine's own output — they are **engine-pinned**, so 0% is an
internal consistency check, not accuracy against human ground truth. Circular.

## What

Recasts the docs around the **only** human-authored Mirandese gold: the 219-word
[`TigreGotico/mirandese_g2p`](https://huggingface.co/datasets/TigreGotico/mirandese_g2p)
dictionary (central 206 / sendinese 11 / raiano 2, routed to `mwl` /
`mwl-x-sendim` / `mwl-x-ifanes`). Full dataset, no caps.

### Human-gold PER (routed, full set)

| system | strict | folded | broad |
|--------|-------:|-------:|------:|
| pure lattice (default) | 22.23% | 19.50% | 13.10% |
| + CRF, 5-fold CV (honest OOD) | 21.18% | 18.16% | 12.73% |
| + CRF, fit to dict (circular) | 8.79% | 3.83% | 2.59% |
| lexicon lookup (memorisation) | 0.25% | 0.28% | 0.30% |

- **strict** = structural markers only removed. **folded** = + stress/length/tie-bars.
  **broad** = + documented narrow→broad convention (`ʉʊ→u`, `ð→d`, `ɫ→l`, `e̞→e`,
  sibilant diacritics), leaving residual *true* phonemic error.

### Default decision: unchanged (pure lattice)

lookup ≈ 0% is memorisation (lexicon *is* the gold) and mixes the narrow lexicon
convention into broad sentences. CRF-fit is circular. CRF 5-fold CV is the honest
OOD number and edges the lattice by ~1.3pp folded — but on the convention-neutral
**broad** basis the gap is **0.37pp** (12.73% vs 13.10%): the CRF mostly matches
the lexicon's narrow convention, not real accuracy, and couples every output to
it. So the untrained, convention-neutral lattice stays the default; CRF and
lookup remain opt-in — now justified by human-gold numbers, not a circular 0%.

The engine sentence set is retained in `evaluate.py` but explicitly labelled a
consistency check, printed last under a NOT-accuracy banner.

Tests: 39 passed.